### PR TITLE
migrate from `error-chain` to `failure` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords    = ["tun", "network", "tunnel", "bindings"]
 
 [dependencies]
 libc        = "0.2"
-error-chain = "0.11"
+failure     = "0.1.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 ioctl-sys = "0.5"

--- a/src/address.rs
+++ b/src/address.rs
@@ -15,16 +15,16 @@
 use std::net::{IpAddr, Ipv4Addr};
 use std::net::{SocketAddr, SocketAddrV4};
 
-use error::*;
+use error::Error;
 
 /// Helper trait to convert things into IPv4 addresses.
 pub trait IntoAddress {
 	/// Convert the type to an `Ipv4Addr`.
-	fn into_address(&self) -> Result<Ipv4Addr>;
+	fn into_address(&self) -> Result<Ipv4Addr, Error>;
 }
 
 impl IntoAddress for u32 {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		Ok(Ipv4Addr::new(
 			((*self      ) & 0xff) as u8,
 			((*self >>  8) & 0xff) as u8,
@@ -34,97 +34,97 @@ impl IntoAddress for u32 {
 }
 
 impl IntoAddress for i32 {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		(*self as u32).into_address()
 	}
 }
 
 impl IntoAddress for (u8, u8, u8, u8) {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		Ok(Ipv4Addr::new(self.0, self.1, self.2, self.3))
 	}
 }
 
 impl IntoAddress for str {
-	fn into_address(&self) -> Result<Ipv4Addr> {
-		self.parse().map_err(|_| ErrorKind::InvalidAddress.into())
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
+		self.parse().map_err(|_| Error::InvalidAddress)
 	}
 }
 
 impl<'a> IntoAddress for &'a str {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		(*self).into_address()
 	}
 }
 
 impl IntoAddress for String {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		(&**self).into_address()
 	}
 }
 
 impl<'a> IntoAddress for &'a String {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		(&**self).into_address()
 	}
 }
 
 impl IntoAddress for Ipv4Addr {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		Ok(self.clone())
 	}
 }
 
 impl<'a> IntoAddress for &'a Ipv4Addr {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		(&**self).into_address()
 	}
 }
 
 impl IntoAddress for IpAddr {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		match *self {
 			IpAddr::V4(ref value) =>
 				Ok(value.clone()),
 
 			IpAddr::V6(_) =>
-				Err(ErrorKind::InvalidAddress.into())
+				Err(Error::InvalidAddress)
 		}
 	}
 }
 
 impl<'a> IntoAddress for &'a IpAddr {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		(&**self).into_address()
 	}
 }
 
 impl IntoAddress for SocketAddrV4 {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		Ok(self.ip().clone())
 	}
 }
 
 impl<'a> IntoAddress for &'a SocketAddrV4 {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		(&**self).into_address()
 	}
 }
 
 impl IntoAddress for SocketAddr {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		match *self {
 			SocketAddr::V4(ref value) =>
 				Ok(value.ip().clone()),
 
 			SocketAddr::V6(_) =>
-				Err(ErrorKind::InvalidAddress.into())
+				Err(Error::InvalidAddress)
 		}
 	}
 }
 
 impl<'a> IntoAddress for &'a SocketAddr {
-	fn into_address(&self) -> Result<Ipv4Addr> {
+	fn into_address(&self) -> Result<Ipv4Addr, Error> {
 		(&**self).into_address()
 	}
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -15,13 +15,13 @@
 use std::io::{Read, Write};
 use std::net::Ipv4Addr;
 
-use error::*;
+use error::Error;
 use configuration::Configuration;
 
 /// A TUN device.
 pub trait Device: Read + Write {
 	/// Reconfigure the device.
-	fn configure(&mut self, config: &Configuration) -> Result<()> {
+	fn configure(&mut self, config: &Configuration) -> Result<(), Error> {
 		if let Some(ip) = config.address {
 			self.set_address(ip)?;
 		}
@@ -51,38 +51,38 @@ pub trait Device: Read + Write {
 	fn name(&self) -> &str;
 
 	/// Set the device name.
-	fn set_name(&mut self, name: &str) -> Result<()>;
+	fn set_name(&mut self, name: &str) -> Result<(), Error>;
 
 	/// Turn on or off the interface.
-	fn enabled(&mut self, value: bool) -> Result<()>;
+	fn enabled(&mut self, value: bool) -> Result<(), Error>;
 
 	/// Get the address.
-	fn address(&self) -> Result<Ipv4Addr>;
+	fn address(&self) -> Result<Ipv4Addr, Error>;
 
 	/// Set the address.
-	fn set_address(&mut self, value: Ipv4Addr) -> Result<()>;
+	fn set_address(&mut self, value: Ipv4Addr) -> Result<(), Error>;
 
 	/// Get the destination address.
-	fn destination(&self) -> Result<Ipv4Addr>;
+	fn destination(&self) -> Result<Ipv4Addr, Error>;
 
 	/// Set the destination address.
-	fn set_destination(&mut self, value: Ipv4Addr) -> Result<()>;
+	fn set_destination(&mut self, value: Ipv4Addr) -> Result<(), Error>;
 
 	/// Get the broadcast address.
-	fn broadcast(&self) -> Result<Ipv4Addr>;
+	fn broadcast(&self) -> Result<Ipv4Addr, Error>;
 
 	/// Set the broadcast address.
-	fn set_broadcast(&mut self, value: Ipv4Addr) -> Result<()>;
+	fn set_broadcast(&mut self, value: Ipv4Addr) -> Result<(), Error>;
 
 	/// Get the netmask.
-	fn netmask(&self) -> Result<Ipv4Addr>;
+	fn netmask(&self) -> Result<Ipv4Addr, Error>;
 
 	/// Set the netmask.
-	fn set_netmask(&mut self, value: Ipv4Addr) -> Result<()>;
+	fn set_netmask(&mut self, value: Ipv4Addr) -> Result<(), Error>;
 
 	/// Get the MTU.
-	fn mtu(&self) -> Result<i32>;
+	fn mtu(&self) -> Result<i32, Error>;
 
 	/// Set the MTU.
-	fn set_mtu(&mut self, value: i32) -> Result<()>;
+	fn set_mtu(&mut self, value: i32) -> Result<(), Error>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,17 +12,46 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-error_chain! {
-	errors {
-		NameTooLong
-		InvalidName
-		InvalidAddress
-		InvalidDescriptor
-	}
+use std::{ffi, io, num};
 
-	foreign_links {
-		Io(::std::io::Error);
-		Nul(::std::ffi::NulError);
-		ParseNum(::std::num::ParseIntError);
-	}
+#[derive(Debug, Fail)]
+pub enum Error {
+    #[fail(display = "Name too long")]
+    NameTooLong,
+
+    #[fail(display = "Invalid name")]
+    InvalidName,
+
+    #[fail(display = "Invalid address")]
+    InvalidAddress,
+
+    #[fail(display = "Invalid descriptor")]
+    InvalidDescriptor,
+
+    #[fail(display = "IO error: {}", error)]
+    Io { error: io::Error },
+
+    #[fail(display = "FFI nul error: {}", error)]
+    Nul { error: ffi::NulError },
+
+    #[fail(display = "Integer parse error: {}", error)]
+    ParseNum { error: num::ParseIntError },
+}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Error::Io { error }
+    }
+}
+
+impl From<num::ParseIntError> for Error {
+    fn from(error: num::ParseIntError) -> Self {
+        Error::ParseNum { error }
+    }
+}
+
+impl From<ffi::NulError> for Error {
+    fn from(error: ffi::NulError) -> Self {
+        Error::Nul { error }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 
 extern crate libc;
 #[macro_use]
-extern crate error_chain;
+extern crate failure;
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[macro_use]
@@ -26,7 +26,7 @@ extern crate ioctl_sys as ioctl;
 extern crate mio;
 
 mod error;
-pub use error::*;
+pub use error::Error;
 
 mod address;
 pub use address::IntoAddress;

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -24,7 +24,7 @@ use libc;
 use libc::{c_char};
 use libc::{AF_INET, SOCK_DGRAM, O_RDWR};
 
-use error::*;
+use error::Error;
 use device::Device as D;
 use platform::posix::{self, SockAddr, Fd};
 use platform::linux::sys::*;
@@ -39,7 +39,7 @@ pub struct Device {
 
 impl Device {
 	/// Create a new `Device` for the given `Configuration`.
-	pub fn new(config: &Configuration) -> Result<Self> {
+	pub fn new(config: &Configuration) -> Result<Self, Error> {
 		let mut device = unsafe {
 			let dev = match config.name.as_ref() {
 				Some(name) => {
@@ -96,7 +96,7 @@ impl Device {
 	}
 
 	/// Make the device persistent.
-	pub fn persist(&mut self) -> Result<()> {
+	pub fn persist(&mut self) -> Result<(), Error> {
 		unsafe {
 			if tunsetpersist(self.tun.as_raw_fd(), &1) < 0 {
 				Err(io::Error::last_os_error().into())
@@ -108,7 +108,7 @@ impl Device {
 	}
 
 	/// Set the owner of the device.
-	pub fn user(&mut self, value: i32) -> Result<()> {
+	pub fn user(&mut self, value: i32) -> Result<(), Error> {
 		unsafe {
 			if tunsetowner(self.tun.as_raw_fd(), &value) < 0 {
 				Err(io::Error::last_os_error().into())
@@ -120,7 +120,7 @@ impl Device {
 	}
 
 	/// Set the group of the device.
-	pub fn group(&mut self, value: i32) -> Result<()> {
+	pub fn group(&mut self, value: i32) -> Result<(), Error> {
 		unsafe {
 			if tunsetgroup(self.tun.as_raw_fd(), &value) < 0 {
 				Err(io::Error::last_os_error().into())
@@ -159,7 +159,7 @@ impl D for Device {
 		&self.name
 	}
 
-	fn set_name(&mut self, value: &str) -> Result<()> {
+	fn set_name(&mut self, value: &str) -> Result<(), Error> {
 		unsafe {
 			let name = CString::new(value)?;
 
@@ -180,7 +180,7 @@ impl D for Device {
 		}
 	}
 
-	fn enabled(&mut self, value: bool) -> Result<()> {
+	fn enabled(&mut self, value: bool) -> Result<(), Error> {
 		unsafe {
 			let mut req = self.request();
 
@@ -203,7 +203,7 @@ impl D for Device {
 		}
 	}
 
-	fn address(&self) -> Result<Ipv4Addr> {
+	fn address(&self) -> Result<Ipv4Addr, Error> {
 		unsafe {
 			let mut req = self.request();
 
@@ -215,7 +215,7 @@ impl D for Device {
 		}
 	}
 
-	fn set_address(&mut self, value: Ipv4Addr) -> Result<()> {
+	fn set_address(&mut self, value: Ipv4Addr) -> Result<(), Error> {
 		unsafe {
 			let mut req   = self.request();
 			req.ifru.addr = SockAddr::from(value).into();
@@ -228,7 +228,7 @@ impl D for Device {
 		}
 	}
 
-	fn destination(&self) -> Result<Ipv4Addr> {
+	fn destination(&self) -> Result<Ipv4Addr, Error> {
 		unsafe {
 			let mut req = self.request();
 
@@ -240,7 +240,7 @@ impl D for Device {
 		}
 	}
 
-	fn set_destination(&mut self, value: Ipv4Addr) -> Result<()> {
+	fn set_destination(&mut self, value: Ipv4Addr) -> Result<(), Error> {
 		unsafe {
 			let mut req      = self.request();
 			req.ifru.dstaddr = SockAddr::from(value).into();
@@ -253,7 +253,7 @@ impl D for Device {
 		}
 	}
 
-	fn broadcast(&self) -> Result<Ipv4Addr> {
+	fn broadcast(&self) -> Result<Ipv4Addr, Error> {
 		unsafe {
 			let mut req = self.request();
 
@@ -265,7 +265,7 @@ impl D for Device {
 		}
 	}
 
-	fn set_broadcast(&mut self, value: Ipv4Addr) -> Result<()> {
+	fn set_broadcast(&mut self, value: Ipv4Addr) -> Result<(), Error> {
 		unsafe {
 			let mut req        = self.request();
 			req.ifru.broadaddr = SockAddr::from(value).into();
@@ -278,7 +278,7 @@ impl D for Device {
 		}
 	}
 
-	fn netmask(&self) -> Result<Ipv4Addr> {
+	fn netmask(&self) -> Result<Ipv4Addr, Error> {
 		unsafe {
 			let mut req = self.request();
 
@@ -290,7 +290,7 @@ impl D for Device {
 		}
 	}
 
-	fn set_netmask(&mut self, value: Ipv4Addr) -> Result<()> {
+	fn set_netmask(&mut self, value: Ipv4Addr) -> Result<(), Error> {
 		unsafe {
 			let mut req      = self.request();
 			req.ifru.netmask = SockAddr::from(value).into();
@@ -303,7 +303,7 @@ impl D for Device {
 		}
 	}
 
-	fn mtu(&self) -> Result<i32> {
+	fn mtu(&self) -> Result<i32, Error> {
 		unsafe {
 			let mut req = self.request();
 
@@ -315,7 +315,7 @@ impl D for Device {
 		}
 	}
 
-	fn set_mtu(&mut self, value: i32) -> Result<()> {
+	fn set_mtu(&mut self, value: i32) -> Result<(), Error> {
 		unsafe {
 			let mut req  = self.request();
 			req.ifru.mtu = value;

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -19,7 +19,7 @@ pub mod sys;
 mod device;
 pub use self::device::Device;
 
-use error::*;
+use error::Error;
 use configuration::Configuration as C;
 
 /// Linux-only interface configuration.
@@ -38,6 +38,6 @@ impl Configuration {
 }
 
 /// Create a TUN device with the given name.
-pub fn create(configuration: &C) -> Result<Device> {
+pub fn create(configuration: &C) -> Result<Device, Error> {
 	Device::new(&configuration)
 }

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -20,13 +20,13 @@ mod device;
 pub use self::device::Device;
 
 use configuration::Configuration as C;
-use error::*;
+use error::Error;
 
 /// macOS-only interface configuration.
 #[derive(Copy, Clone, Default, Debug)]
 pub struct Configuration { }
 
 /// Create a TUN device with the given name.
-pub fn create(configuration: &C) -> Result<Device> {
+pub fn create(configuration: &C) -> Result<Device, Error> {
 	Device::new(&configuration)
 }

--- a/src/platform/posix/fd.rs
+++ b/src/platform/posix/fd.rs
@@ -16,15 +16,15 @@ use std::io::{self, Read, Write};
 use std::os::unix::io::{RawFd, AsRawFd};
 
 use libc;
-use error::*;
+use error::Error;
 
 /// POSIX file descriptor support for `io` traits and optionally for `mio`.
 pub struct Fd(pub RawFd);
 
 impl Fd {
-	pub fn new(value: RawFd) -> Result<Self> {
+	pub fn new(value: RawFd) -> Result<Self, Error> {
 		if value < 0 {
-			return Err(ErrorKind::InvalidDescriptor.into());
+			return Err(Error::InvalidDescriptor);
 		}
 
 		Ok(Fd(value))

--- a/src/platform/posix/sockaddr.rs
+++ b/src/platform/posix/sockaddr.rs
@@ -24,7 +24,7 @@ use libc::{c_uint, c_uchar};
 use libc::{sockaddr, sockaddr_in, in_addr};
 use libc::AF_INET as _AF_INET;
 
-use error::*;
+use error::Error;
 
 /// A wrapper for `sockaddr_in`.
 #[derive(Copy, Clone)]
@@ -38,16 +38,16 @@ const AF_INET: c_uchar = _AF_INET as c_uchar;
 
 impl SockAddr {
 	/// Create a new `SockAddr` from a generic `sockaddr`.
-	pub fn new(value: &sockaddr) -> Result<Self> {
+	pub fn new(value: &sockaddr) -> Result<Self, Error> {
 		if value.sa_family != AF_INET {
-			return Err(ErrorKind::InvalidAddress.into());
+			return Err(Error::InvalidAddress);
 		}
 
 		unsafe { Self::unchecked(value) }
 	}
 
 	///  Create a new `SockAddr` and not check the source.
-	pub unsafe fn unchecked(value: &sockaddr) -> Result<Self> {
+	pub unsafe fn unchecked(value: &sockaddr) -> Result<Self, Error> {
 		Ok(SockAddr(ptr::read(value as *const _ as *const _)))
 	}
 


### PR DESCRIPTION
Now that the Failure crate is out and solidified, it's set to be the replacement for error-chain and is a pretty straightforward migration.

I opted not to create special Result type since I personally find it more clear this way, but if you'd prefer to use the single-parameter custom Result like error-chain advocates, I can make that change.