### PR TITLE
Add raw fd traits

### DIFF
--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -15,7 +15,7 @@
 use std::mem;
 use std::ptr;
 use std::io::{self, Read, Write};
-use std::os::unix::io::{RawFd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd, IntoRawFd};
 use std::ffi::{CString, CStr};
 use std::net::{Ipv4Addr};
 use std::sync::Arc;
@@ -332,6 +332,12 @@ impl D for Device {
 impl AsRawFd for Device {
 	fn as_raw_fd(&self) -> RawFd {
 		self.tun.as_raw_fd()
+	}
+}
+
+impl IntoRawFd for Device {
+	fn into_raw_fd(self) -> RawFd {
+		self.tun.into_raw_fd()
 	}
 }
 

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -19,7 +19,7 @@ use std::ffi::CStr;
 use std::sync::Arc;
 use std::net::Ipv4Addr;
 use std::io::{self, Read, Write};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 
 use libc;
 use libc::{SOCK_DGRAM, AF_INET, socklen_t, sockaddr, c_void, c_char, c_uint};
@@ -314,6 +314,18 @@ impl D for Device {
 
 			Ok(())
 		}
+	}
+}
+
+impl AsRawFd for Device {
+	fn as_raw_fd(&self) -> RawFd {
+		self.tun.as_raw_fd()
+	}
+}
+
+impl IntoRawFd for Device {
+	fn into_raw_fd(self) -> RawFd {
+		self.tun.into_raw_fd()
 	}
 }
 

--- a/src/platform/posix/fd.rs
+++ b/src/platform/posix/fd.rs
@@ -13,7 +13,7 @@
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
 use std::io::{self, Read, Write};
-use std::os::unix::io::{RawFd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd, IntoRawFd};
 
 use libc;
 use error::*;
@@ -69,10 +69,20 @@ impl AsRawFd for Fd {
 	}
 }
 
+impl IntoRawFd for Fd {
+	fn into_raw_fd(mut self) -> RawFd {
+		let fd = self.0;
+		self.0 = -1;
+		fd
+	}
+}
+
 impl Drop for Fd {
 	fn drop(&mut self) {
 		unsafe {
-			libc::close(self.0);
+			if self.0 >= 0 {
+				libc::close(self.0);
+			}
 		}
 	}
 }


### PR DESCRIPTION
I noticed the lack of `AsRawFd` for the `Device` struct on MacOS, so I've implemented that and also `IntoRawFd`, as that's my _actual_ use case. If however you don't wish to have the device be capable of being irreversibly turned into a raw file descriptor, I'm OK with not making that change :slightly_smiling_face:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/meh/rust-tun/10)
<!-- Reviewable:end -->
