### PR TITLE
Don't try to enable interface unless requested.

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -28,7 +28,7 @@ pub struct Configuration {
 	pub(crate) broadcast:   Option<Ipv4Addr>,
 	pub(crate) netmask:     Option<Ipv4Addr>,
 	pub(crate) mtu:         Option<i32>,
-	pub(crate) enabled:     bool,
+	pub(crate) enabled:     Option<bool>,
 }
 
 impl Configuration {
@@ -78,13 +78,13 @@ impl Configuration {
 
 	/// Set the interface to be enabled once created.
 	pub fn up(&mut self) -> &mut Self {
-		self.enabled = true;
+		self.enabled = Some(true);
 		self
 	}
 
 	/// Set the interface to be disabled once created.
 	pub fn down(&mut self) -> &mut Self {
-		self.enabled = false;
+		self.enabled = Some(false);
 		self
 	}
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -42,7 +42,9 @@ pub trait Device: Read + Write {
 			self.set_mtu(mtu)?;
 		}
 
-		self.enabled(config.enabled)?;
+		if let Some(enabled) = config.enabled {
+			self.enabled(enabled)?;
+		}
 
 		Ok(())
 	}


### PR DESCRIPTION
With this simple change I am able to run my code as unprivileged user.

I can set ip address and bring up interface from shell script or systemd, and then run my application as a normal user instead of root.