### PR TITLE
feat: add L2 devices support

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -17,6 +17,17 @@ use std::net::{Ipv4Addr};
 use crate::address::IntoAddress;
 use crate::platform;
 
+/// TUN interface OSI layer of operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Layer {
+	L2,
+	L3,
+}
+
+impl Default for Layer {
+	fn default() -> Self { Layer::L3 }
+}
+
 /// Configuration builder for a TUN interface.
 #[derive(Clone, Default, Debug)]
 pub struct Configuration {
@@ -29,6 +40,7 @@ pub struct Configuration {
 	pub(crate) netmask:     Option<Ipv4Addr>,
 	pub(crate) mtu:         Option<i32>,
 	pub(crate) enabled:     Option<bool>,
+	pub(crate) layer:       Option<Layer>,
 }
 
 impl Configuration {
@@ -85,6 +97,12 @@ impl Configuration {
 	/// Set the interface to be disabled once created.
 	pub fn down(&mut self) -> &mut Self {
 		self.enabled = Some(false);
+		self
+	}
+
+	/// Set the OSI layer of operation.
+	pub fn layer(&mut self, l: Layer) -> &mut Self {
+		self.layer = Some(l);
 		self
 	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,9 @@ pub enum Error {
 	#[error("invalid file descriptor")]
 	InvalidDescriptor,
 
+	#[error("unsuported network layer of operation")]
+	UnsupportedLayer,
+
 	#[error(transparent)]
 	Io(#[from] io::Error),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ mod device;
 pub use crate::device::Device;
 
 mod configuration;
-pub use crate::configuration::Configuration;
+pub use crate::configuration::{Configuration, Layer};
 
 pub mod platform;
 pub use crate::platform::create;

--- a/src/platform/linux/sys.rs
+++ b/src/platform/linux/sys.rs
@@ -24,6 +24,7 @@ pub const IFF_UP:      c_short = 0x1;
 pub const IFF_RUNNING: c_short = 0x40;
 
 pub const IFF_TUN:   c_short = 0x0001;
+pub const IFF_TAP:   c_short = 0x0002;
 pub const IFF_NO_PI: c_short = 0x1000;
 
 #[repr(C)]

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -42,11 +42,11 @@ impl Device {
 	pub fn new(config: &Configuration) -> Result<Self> {
 		let id = if let Some(name) = config.name.as_ref() {
 			if name.len() > IFNAMSIZ {
-				return Err(ErrorKind::NameTooLong.into());
+				return Err(Error::NameTooLong);
 			}
 
 			if !name.starts_with("utun") {
-				return Err(ErrorKind::InvalidName.into());
+				return Err(Error::InvalidName);
 			}
 
 			name[4..].parse()?
@@ -56,7 +56,7 @@ impl Device {
 		};
 
 		if config.layer.filter(|l| *l != Layer::L3).is_some() {
-			return Err(ErrorKind::UnsupportedLayer.into());
+			return Err(Error::UnsupportedLayer);
 		}
 
 		let mut device = unsafe {
@@ -180,7 +180,7 @@ impl D for Device {
 
 	// XXX: Cannot set interface name on Darwin.
 	fn set_name(&mut self, value: &str) -> Result<()> {
-		Err(ErrorKind::InvalidName.into())
+		Err(Error::InvalidName)
 	}
 
 	fn enabled(&mut self, value: bool) -> Result<()> {

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -27,7 +27,7 @@ use libc::{SOCK_DGRAM, AF_INET, socklen_t, sockaddr, c_void, c_char, c_uint};
 use crate::error::*;
 use crate::device::Device as D;
 use crate::platform::macos::sys::*;
-use crate::configuration::Configuration;
+use crate::configuration::{Configuration, Layer};
 use crate::platform::posix::{self, SockAddr, Fd};
 
 /// A TUN device using the TUN macOS driver.
@@ -54,6 +54,10 @@ impl Device {
 		else {
 			0
 		};
+
+		if config.layer.filter(|l| *l != Layer::L3).is_some() {
+			return Err(ErrorKind::UnsupportedLayer.into());
+		}
 
 		let mut device = unsafe {
 			let tun = Fd::new(libc::socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL))


### PR DESCRIPTION
This commit adds support for L2 tun devices.

L2 tun devices are supported only on Linux, so trying to create one on
OSX will return an UnsupportedLayer error.