### PR TITLE
feat: add enable/disable methods to Device

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -87,4 +87,10 @@ pub trait Device: Read + Write {
 
 	/// Set the MTU.
 	fn set_mtu(&mut self, value: i32) -> Result<()>;
+
+	/// Enable the tun device.
+	fn enable(&mut self) -> Result<()>;
+
+	/// Disable the tun device.
+	fn disable(&mut self) -> Result<()>;
 }

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -347,6 +347,14 @@ impl D for Device {
 			Ok(())
 		}
 	}
+
+	fn enable(&mut self) -> Result<()> {
+	      self.enabled(true)
+	}
+
+	fn disable(&mut self) -> Result<()> {
+	      self.enabled(false)
+	}
 }
 
 impl AsRawFd for Device {

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -330,6 +330,14 @@ impl D for Device {
 			Ok(())
 		}
 	}
+
+	fn enable(&mut self) -> Result<()> {
+	      self.enabled(true)
+	}
+
+	fn disable(&mut self) -> Result<()> {
+	      self.enabled(false)
+	}
 }
 
 impl AsRawFd for Device {


### PR DESCRIPTION
These methods allows to control weather a device is enabled or disabled
(i.e. the device link is up or down) after the device initial
configuration.