### PR TITLE
feat: add multiqueue support

### DIFF
--- a/src/async/device.rs
+++ b/src/async/device.rs
@@ -19,7 +19,7 @@ use core::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, PollEvented};
 use tokio_util::codec::Framed;
 
-use crate::platform::Device;
+use crate::platform::{Device, Queue};
 use crate::r#async::codec::*;
 
 /// An async TUN device wrapper around a TUN device.
@@ -64,6 +64,65 @@ impl AsyncRead for DeviceAsync {
 }
 
 impl AsyncWrite for DeviceAsync {
+	fn poll_write(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buf: &[u8],
+	) -> Poll<io::Result<usize>> {
+		Pin::new(&mut self.inner).poll_write(cx, buf)
+	}
+
+	fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		Pin::new(&mut self.inner).poll_flush(cx)
+	}
+
+	fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		Pin::new(&mut self.inner).poll_shutdown(cx)
+	}
+}
+
+/// An async TUN device queue wrapper around a TUN device queue.
+pub struct QueueAsync {
+	inner: PollEvented<Queue>,
+}
+
+impl QueueAsync {
+	/// Create a new `QueueAsync` wrapping around a `Queue`.
+	pub fn new(queue: Queue) -> io::Result<QueueAsync> {
+		queue.set_nonblock()?;
+		Ok(QueueAsync {
+			inner: PollEvented::new(queue)?,
+		})
+	}
+	/// Returns a shared reference to the underlying Queue object
+	pub fn get_ref(&self) -> &Queue {
+		self.inner.get_ref()
+	}
+
+	/// Returns a mutable reference to the underlying Queue object
+	pub fn get_mut(&mut self) -> &mut Queue {
+		self.inner.get_mut()
+	}
+
+	/// Consumes this QueueAsync and return a Framed object (unified Stream and Sink interface)
+	pub fn into_framed(mut self) -> Framed<Self, TunPacketCodec> {
+		let pi = self.get_mut().has_packet_information();
+		let codec = TunPacketCodec::new(pi);
+		Framed::new(self, codec)
+	}
+}
+
+impl AsyncRead for QueueAsync {
+	fn poll_read(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buf: &mut [u8],
+	) -> Poll<io::Result<usize>> {
+		Pin::new(&mut self.inner).poll_read(cx, buf)
+	}
+}
+
+impl AsyncWrite for QueueAsync {
 	fn poll_write(
 		mut self: Pin<&mut Self>,
 		cx: &mut Context<'_>,

--- a/src/async/device.rs
+++ b/src/async/device.rs
@@ -23,15 +23,15 @@ use crate::platform::{Device, Queue};
 use crate::r#async::codec::*;
 
 /// An async TUN device wrapper around a TUN device.
-pub struct DeviceAsync {
+pub struct AsyncDevice {
 	inner: PollEvented<Device>,
 }
 
-impl DeviceAsync {
-	/// Create a new `DeviceAsync` wrapping around a `Device`.
-	pub fn new(device: Device) -> io::Result<DeviceAsync> {
+impl AsyncDevice {
+	/// Create a new `AsyncDevice` wrapping around a `Device`.
+	pub fn new(device: Device) -> io::Result<AsyncDevice> {
 		device.set_nonblock()?;
-		Ok(DeviceAsync {
+		Ok(AsyncDevice {
 			inner: PollEvented::new(device)?,
 		})
 	}
@@ -45,7 +45,7 @@ impl DeviceAsync {
 		self.inner.get_mut()
 	}
 
-	/// Consumes this DeviceAsync and return a Framed object (unified Stream and Sink interface)
+	/// Consumes this AsyncDevice and return a Framed object (unified Stream and Sink interface)
 	pub fn into_framed(mut self) -> Framed<Self, TunPacketCodec> {
 		let pi = self.get_mut().has_packet_information();
 		let codec = TunPacketCodec::new(pi);
@@ -53,7 +53,7 @@ impl DeviceAsync {
 	}
 }
 
-impl AsyncRead for DeviceAsync {
+impl AsyncRead for AsyncDevice {
 	fn poll_read(
 		mut self: Pin<&mut Self>,
 		cx: &mut Context<'_>,
@@ -63,7 +63,7 @@ impl AsyncRead for DeviceAsync {
 	}
 }
 
-impl AsyncWrite for DeviceAsync {
+impl AsyncWrite for AsyncDevice {
 	fn poll_write(
 		mut self: Pin<&mut Self>,
 		cx: &mut Context<'_>,
@@ -82,15 +82,15 @@ impl AsyncWrite for DeviceAsync {
 }
 
 /// An async TUN device queue wrapper around a TUN device queue.
-pub struct QueueAsync {
+pub struct AsyncQueue {
 	inner: PollEvented<Queue>,
 }
 
-impl QueueAsync {
-	/// Create a new `QueueAsync` wrapping around a `Queue`.
-	pub fn new(queue: Queue) -> io::Result<QueueAsync> {
+impl AsyncQueue {
+	/// Create a new `AsyncQueue` wrapping around a `Queue`.
+	pub fn new(queue: Queue) -> io::Result<AsyncQueue> {
 		queue.set_nonblock()?;
-		Ok(QueueAsync {
+		Ok(AsyncQueue {
 			inner: PollEvented::new(queue)?,
 		})
 	}
@@ -104,7 +104,7 @@ impl QueueAsync {
 		self.inner.get_mut()
 	}
 
-	/// Consumes this QueueAsync and return a Framed object (unified Stream and Sink interface)
+	/// Consumes this AsyncQueue and return a Framed object (unified Stream and Sink interface)
 	pub fn into_framed(mut self) -> Framed<Self, TunPacketCodec> {
 		let pi = self.get_mut().has_packet_information();
 		let codec = TunPacketCodec::new(pi);
@@ -112,7 +112,7 @@ impl QueueAsync {
 	}
 }
 
-impl AsyncRead for QueueAsync {
+impl AsyncRead for AsyncQueue {
 	fn poll_read(
 		mut self: Pin<&mut Self>,
 		cx: &mut Context<'_>,
@@ -122,7 +122,7 @@ impl AsyncRead for QueueAsync {
 	}
 }
 
-impl AsyncWrite for QueueAsync {
+impl AsyncWrite for AsyncQueue {
 	fn poll_write(
 		mut self: Pin<&mut Self>,
 		cx: &mut Context<'_>,

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -20,7 +20,7 @@ use crate::configuration::Configuration;
 use crate::platform::create;
 
 mod device;
-pub use self::device::DeviceAsync;
+pub use self::device::{DeviceAsync, QueueAsync};
 
 mod codec;
 pub use self::codec::{TunPacket, TunPacketCodec};

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -20,13 +20,13 @@ use crate::configuration::Configuration;
 use crate::platform::create;
 
 mod device;
-pub use self::device::{DeviceAsync, QueueAsync};
+pub use self::device::{AsyncDevice, AsyncQueue};
 
 mod codec;
 pub use self::codec::{TunPacket, TunPacketCodec};
 
 /// Create a TUN device with the given name.
-pub fn create_as_async(configuration: &Configuration) -> Result<DeviceAsync, error::Error> {
+pub fn create_as_async(configuration: &Configuration) -> Result<AsyncDevice, error::Error> {
     let device = create(&configuration)?;
-    DeviceAsync::new(device).map_err(|err| err.into())
+    AsyncDevice::new(device).map_err(|err| err.into())
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -41,6 +41,7 @@ pub struct Configuration {
 	pub(crate) mtu:         Option<i32>,
 	pub(crate) enabled:     Option<bool>,
 	pub(crate) layer:       Option<Layer>,
+	pub(crate) queues:      Option<usize>,
 }
 
 impl Configuration {
@@ -101,8 +102,14 @@ impl Configuration {
 	}
 
 	/// Set the OSI layer of operation.
-	pub fn layer(&mut self, l: Layer) -> &mut Self {
-		self.layer = Some(l);
+	pub fn layer(&mut self, value: Layer) -> &mut Self {
+		self.layer = Some(value);
+		self
+	}
+
+	/// Set the number of queues.
+	pub fn queues(&mut self, value: usize) -> &mut Self {
+		self.queues = Some(value);
 		self
 	}
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -20,6 +20,8 @@ use crate::configuration::Configuration;
 
 /// A TUN device.
 pub trait Device: Read + Write {
+	type Queue: Read + Write;
+
 	/// Reconfigure the device.
 	fn configure(&mut self, config: &Configuration) -> Result<()> {
 		if let Some(ip) = config.address {
@@ -87,4 +89,7 @@ pub trait Device: Read + Write {
 
 	/// Set the MTU.
 	fn set_mtu(&mut self, value: i32) -> Result<()>;
+
+	/// Get a device queue.
+	fn queue(&mut self, index: usize) -> Option<&mut Self::Queue>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,9 @@ pub enum Error {
 	#[error("unsuported network layer of operation")]
 	UnsupportedLayer,
 
+	#[error("invalid queues number")]
+	InvalidQueuesNumber,
+
 	#[error(transparent)]
 	Io(#[from] io::Error),
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -17,7 +17,7 @@
 pub mod sys;
 
 mod device;
-pub use self::device::Device;
+pub use self::device::{Device, Queue};
 
 use crate::error::*;
 use crate::configuration::Configuration as C;

--- a/src/platform/linux/sys.rs
+++ b/src/platform/linux/sys.rs
@@ -23,9 +23,10 @@ pub const IFNAMSIZ: usize = 16;
 pub const IFF_UP:      c_short = 0x1;
 pub const IFF_RUNNING: c_short = 0x40;
 
-pub const IFF_TUN:   c_short = 0x0001;
-pub const IFF_TAP:   c_short = 0x0002;
-pub const IFF_NO_PI: c_short = 0x1000;
+pub const IFF_TUN:         c_short = 0x0001;
+pub const IFF_TAP:         c_short = 0x0002;
+pub const IFF_NO_PI:       c_short = 0x1000;
+pub const IFF_MULTI_QUEUE: c_short = 0x0100;
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -17,7 +17,7 @@
 pub mod sys;
 
 mod device;
-pub use self::device::Device;
+pub use self::device::{Device, Queue};
 
 use crate::configuration::Configuration as C;
 use crate::error::*;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -20,12 +20,12 @@ pub mod posix;
 #[cfg(target_os = "linux")]
 pub mod linux;
 #[cfg(target_os = "linux")]
-pub use self::linux::{Device, Configuration, create};
+pub use self::linux::{Device, Queue, Configuration, create};
 
 #[cfg(target_os = "macos")]
 pub mod macos;
 #[cfg(target_os = "macos")]
-pub use self::macos::{Device, Configuration, create};
+pub use self::macos::{Device, Queue, Configuration, create};
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
This commit adds support for multiqueue interfaces.

Multiqueue devices are supported only on Linux, so trying to create a
device with more than one queue on OSX will return an
InvalidQueuesNumber error.