### PR TITLE
fix: ignore malformed packets while decoding

### DIFF
--- a/src/async/codec.rs
+++ b/src/async/codec.rs
@@ -99,6 +99,14 @@ impl Decoder for TunPacketCodec {
             return Ok(None);
         }
 
+        if self.0 {
+            // ignore malformed packet
+            if buf.len() <= 4 {
+                let _ = buf.split_to(buf.len());
+                return Ok(None);
+            }
+        }
+
         let mut buf = buf.split_to(buf.len());
 
         // if the packet information is enabled we have to ignore the first 4 bytes


### PR DESCRIPTION
This pr should fix #17, but I don't exactly know why malformed packets are coming from macOS's tun interface.