### PR TITLE
fix: reserve enough space for packet decoding

### DIFF
--- a/src/async/codec.rs
+++ b/src/async/codec.rs
@@ -99,14 +99,6 @@ impl Decoder for TunPacketCodec {
             return Ok(None);
         }
 
-        if self.0 {
-            // ignore malformed packet
-            if buf.len() <= 4 {
-                let _ = buf.split_to(buf.len());
-                return Ok(None);
-            }
-        }
-
         let mut buf = buf.split_to(buf.len());
 
         // if the packet information is enabled we have to ignore the first 4 bytes

--- a/src/async/device.rs
+++ b/src/async/device.rs
@@ -19,6 +19,7 @@ use core::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, PollEvented};
 use tokio_util::codec::Framed;
 
+use crate::device::Device as D;
 use crate::platform::{Device, Queue};
 use crate::r#async::codec::*;
 
@@ -48,7 +49,7 @@ impl AsyncDevice {
     /// Consumes this AsyncDevice and return a Framed object (unified Stream and Sink interface)
     pub fn into_framed(mut self) -> Framed<Self, TunPacketCodec> {
         let pi = self.get_mut().has_packet_information();
-        let codec = TunPacketCodec::new(pi);
+        let codec = TunPacketCodec::new(pi, self.inner.get_ref().mtu().unwrap_or(1504));
         Framed::new(self, codec)
     }
 }
@@ -107,7 +108,7 @@ impl AsyncQueue {
     /// Consumes this AsyncQueue and return a Framed object (unified Stream and Sink interface)
     pub fn into_framed(mut self) -> Framed<Self, TunPacketCodec> {
         let pi = self.get_mut().has_packet_information();
-        let codec = TunPacketCodec::new(pi);
+        let codec = TunPacketCodec::new(pi, 1504);
         Framed::new(self, codec)
     }
 }


### PR DESCRIPTION
The root cause of #17 is the codec fails to reserve enough space for the every packet and resulting truncated packets.