### PR TITLE
Bump ioctl-sys to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bytes      = { version = "0.5", optional = true }
 byteorder  = { version = "1.3", optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-ioctl      = { version = "0.5", package = "ioctl-sys" }
+ioctl      = { version = "0.6", package = "ioctl-sys" }
 
 [dev-dependencies]
 packet     = "0.1"


### PR DESCRIPTION
This adds support for Apple Silicon. Support for it in ioctl-sys was introduced in this PR: https://github.com/jmesmon/ioctl/pull/7