### PR TITLE
feat: add Android support

### DIFF
--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -1,0 +1,246 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+#![allow(unused_variables)]
+
+use std::io::{self, Read, Write};
+use std::net::Ipv4Addr;
+use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
+use std::sync::Arc;
+
+use crate::configuration::Configuration;
+use crate::device::Device as D;
+use crate::error::*;
+use crate::platform::posix::{self, Fd};
+
+/// A TUN device for Android.
+pub struct Device {
+    queue: Queue,
+}
+
+impl Device {
+    /// Create a new `Device` for the given `Configuration`.
+    pub fn new(config: &Configuration) -> Result<Self> {
+        let fd = match config.raw_fd {
+            Some(raw_fd) => raw_fd,
+            _ => return Err(Error::InvalidConfig),
+        };
+        let device = {
+            let tun = Fd::new(fd).map_err(|_| io::Error::last_os_error())?;
+
+            Device {
+                queue: Queue { tun: tun },
+            }
+        };
+        Ok(device)
+    }
+
+    /// Split the interface into a `Reader` and `Writer`.
+    pub fn split(self) -> (posix::Reader, posix::Writer) {
+        let fd = Arc::new(self.queue.tun);
+        (posix::Reader(fd.clone()), posix::Writer(fd.clone()))
+    }
+
+    /// Return whether the device has packet information
+    pub fn has_packet_information(&self) -> bool {
+        self.queue.has_packet_information()
+    }
+
+    #[cfg(feature = "mio")]
+    pub fn set_nonblock(&self) -> io::Result<()> {
+        self.queue.set_nonblock()
+    }
+}
+
+impl Read for Device {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.queue.tun.read(buf)
+    }
+}
+
+impl Write for Device {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.queue.tun.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.queue.tun.flush()
+    }
+}
+
+impl D for Device {
+    type Queue = Queue;
+
+    fn name(&self) -> &str {
+        return "";
+    }
+
+    fn set_name(&mut self, value: &str) -> Result<()> {
+        Err(Error::NotImplemented)
+    }
+
+    fn enabled(&mut self, value: bool) -> Result<()> {
+        Ok(())
+    }
+
+    fn address(&self) -> Result<Ipv4Addr> {
+        Err(Error::NotImplemented)
+    }
+
+    fn set_address(&mut self, value: Ipv4Addr) -> Result<()> {
+        Ok(())
+    }
+
+    fn destination(&self) -> Result<Ipv4Addr> {
+        Err(Error::NotImplemented)
+    }
+
+    fn set_destination(&mut self, value: Ipv4Addr) -> Result<()> {
+        Ok(())
+    }
+
+    fn broadcast(&self) -> Result<Ipv4Addr> {
+        Err(Error::NotImplemented)
+    }
+
+    fn set_broadcast(&mut self, value: Ipv4Addr) -> Result<()> {
+        Ok(())
+    }
+
+    fn netmask(&self) -> Result<Ipv4Addr> {
+        Err(Error::NotImplemented)
+    }
+
+    fn set_netmask(&mut self, value: Ipv4Addr) -> Result<()> {
+        Ok(())
+    }
+
+    fn mtu(&self) -> Result<i32> {
+        Err(Error::NotImplemented)
+    }
+
+    fn set_mtu(&mut self, value: i32) -> Result<()> {
+        Ok(())
+    }
+
+    fn queue(&mut self, index: usize) -> Option<&mut Self::Queue> {
+        if index > 0 {
+            return None;
+        }
+
+        Some(&mut self.queue)
+    }
+}
+
+impl AsRawFd for Device {
+    fn as_raw_fd(&self) -> RawFd {
+        self.queue.tun.as_raw_fd()
+    }
+}
+
+impl IntoRawFd for Device {
+    fn into_raw_fd(self) -> RawFd {
+        self.queue.tun.into_raw_fd()
+    }
+}
+
+pub struct Queue {
+    tun: Fd,
+}
+
+impl Queue {
+    pub fn has_packet_information(&self) -> bool {
+        // on ios this is always the case
+        true
+    }
+
+    #[cfg(feature = "mio")]
+    pub fn set_nonblock(&self) -> io::Result<()> {
+        self.tun.set_nonblock()
+    }
+}
+
+impl Read for Queue {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.tun.read(buf)
+    }
+}
+
+impl Write for Queue {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.tun.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.tun.flush()
+    }
+}
+
+#[cfg(feature = "mio")]
+mod mio {
+    use mio::event::Evented;
+    use mio::{Poll, PollOpt, Ready, Token};
+    use std::io;
+
+    impl Evented for super::Device {
+        fn register(
+            &self,
+            poll: &Poll,
+            token: Token,
+            interest: Ready,
+            opts: PollOpt,
+        ) -> io::Result<()> {
+            self.queue.register(poll, token, interest, opts)
+        }
+
+        fn reregister(
+            &self,
+            poll: &Poll,
+            token: Token,
+            interest: Ready,
+            opts: PollOpt,
+        ) -> io::Result<()> {
+            self.queue.reregister(poll, token, interest, opts)
+        }
+
+        fn deregister(&self, poll: &Poll) -> io::Result<()> {
+            self.queue.deregister(poll)
+        }
+    }
+
+    impl Evented for super::Queue {
+        fn register(
+            &self,
+            poll: &Poll,
+            token: Token,
+            interest: Ready,
+            opts: PollOpt,
+        ) -> io::Result<()> {
+            self.tun.register(poll, token, interest, opts)
+        }
+
+        fn reregister(
+            &self,
+            poll: &Poll,
+            token: Token,
+            interest: Ready,
+            opts: PollOpt,
+        ) -> io::Result<()> {
+            self.tun.reregister(poll, token, interest, opts)
+        }
+
+        fn deregister(&self, poll: &Poll) -> io::Result<()> {
+            self.tun.deregister(poll)
+        }
+    }
+}

--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -160,8 +160,8 @@ pub struct Queue {
 
 impl Queue {
     pub fn has_packet_information(&self) -> bool {
-        // on ios this is always the case
-        true
+        // on Android this is always the case
+        false
     }
 
     #[cfg(feature = "mio")]

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -1,0 +1,30 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+//! Android specific functionality.
+
+mod device;
+pub use self::device::{Device, Queue};
+
+use crate::configuration::Configuration as C;
+use crate::error::*;
+
+/// Android-only interface configuration.
+#[derive(Copy, Clone, Default, Debug)]
+pub struct Configuration {}
+
+/// Create a TUN device with the given name.
+pub fn create(configuration: &C) -> Result<Device> {
+    Device::new(&configuration)
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -32,6 +32,11 @@ pub mod ios;
 #[cfg(target_os = "ios")]
 pub use self::ios::{create, Configuration, Device, Queue};
 
+#[cfg(target_os = "android")]
+pub mod android;
+#[cfg(target_os = "android")]
+pub use self::android::{create, Configuration, Device, Queue};
+
 #[cfg(test)]
 mod test {
     use crate::configuration::Configuration;

--- a/src/platform/posix/sockaddr.rs
+++ b/src/platform/posix/sockaddr.rs
@@ -18,7 +18,7 @@ use std::ptr;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use libc::{c_uchar, c_uint};
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use libc::{c_uint, c_ushort};
 
 use libc::AF_INET as _AF_INET;
@@ -30,7 +30,7 @@ use crate::error::*;
 #[derive(Copy, Clone)]
 pub struct SockAddr(sockaddr_in);
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const AF_INET: c_ushort = _AF_INET as c_ushort;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]


### PR DESCRIPTION
I added a module `android` by simply copying the code and renaming the structs from the `ios` module, and it works well on my Android 10 device.

`VpnService.builder` in Android works like iOS (#21). The tunnel device's file descriptor can be created in Java code and then be passed to the native Rust code.

