### PR TITLE
Upgrade tokio to v1.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name    = "tun"
+name = "tun"
 version = "0.5.1"
 edition = "2018"
 
@@ -7,38 +7,39 @@ authors = ["meh. <meh@schizofreni.co>"]
 license = "WTFPL"
 
 description = "TUN device creation and handling."
-repository  = "https://github.com/meh/rust-tun"
-keywords    = ["tun", "network", "tunnel", "bindings"]
+repository = "https://github.com/meh/rust-tun"
+keywords = ["tun", "network", "tunnel", "bindings"]
 
 [dependencies]
-libc      = "0.2"
+libc = "0.2"
 thiserror = "1"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))'.dependencies]
-mio        = { version = "0.6", optional = true }
-tokio      = { version = "0.2", features = ["full"], optional = true }
-tokio-util = { version = "0.3", features = ["codec"], optional = true }
-bytes      = { version = "0.5", optional = true }
-byteorder  = { version = "1.3", optional = true }
+tokio = { version = "1", features = ["net", "macros"], optional = true }
+tokio-util = { version = "0.6", features = ["codec"], optional = true }
+bytes = { version = "1", optional = true }
+byteorder = { version = "1", optional = true }
+# This is only for the `ready` macro.
+futures-core = { version = "0.3", optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-ioctl      = { version = "0.6", package = "ioctl-sys" }
+ioctl = { version = "0.6", package = "ioctl-sys" }
 
 [dev-dependencies]
-packet     = "0.1"
-futures    = "0.3.1"
+packet = "0.1"
+futures = "0.3"
 
 [features]
-async = ["tokio", "tokio-util", "mio", "bytes", "byteorder"]
+async = ["tokio", "tokio-util", "bytes", "byteorder", "futures-core"]
 
 [[example]]
 name = "read-async"
-required-features = [ "async" ]
+required-features = [ "async", "tokio/rt-multi-thread" ]
 
 [[example]]
 name = "read-async-codec"
-required-features = [ "async" ]
+required-features = [ "async", "tokio/rt-multi-thread" ]
 
 [[example]]
 name = "ping-tun"
-required-features = [ "async" ]
+required-features = [ "async", "tokio/rt-multi-thread" ]

--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -56,7 +56,7 @@ impl Device {
         self.queue.has_packet_information()
     }
 
-    #[cfg(feature = "mio")]
+    #[cfg(feature = "async")]
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.queue.set_nonblock()
     }
@@ -144,13 +144,13 @@ impl D for Device {
 
 impl AsRawFd for Device {
     fn as_raw_fd(&self) -> RawFd {
-        self.queue.tun.as_raw_fd()
+        self.queue.as_raw_fd()
     }
 }
 
 impl IntoRawFd for Device {
     fn into_raw_fd(self) -> RawFd {
-        self.queue.tun.into_raw_fd()
+        self.queue.into_raw_fd()
     }
 }
 
@@ -164,9 +164,21 @@ impl Queue {
         false
     }
 
-    #[cfg(feature = "mio")]
+    #[cfg(feature = "async")]
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.tun.set_nonblock()
+    }
+}
+
+impl AsRawFd for Queue {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tun.as_raw_fd()
+    }
+}
+
+impl IntoRawFd for Queue {
+    fn into_raw_fd(self) -> RawFd {
+        self.tun.into_raw_fd()
     }
 }
 
@@ -183,64 +195,5 @@ impl Write for Queue {
 
     fn flush(&mut self) -> io::Result<()> {
         self.tun.flush()
-    }
-}
-
-#[cfg(feature = "mio")]
-mod mio {
-    use mio::event::Evented;
-    use mio::{Poll, PollOpt, Ready, Token};
-    use std::io;
-
-    impl Evented for super::Device {
-        fn register(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.queue.register(poll, token, interest, opts)
-        }
-
-        fn reregister(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.queue.reregister(poll, token, interest, opts)
-        }
-
-        fn deregister(&self, poll: &Poll) -> io::Result<()> {
-            self.queue.deregister(poll)
-        }
-    }
-
-    impl Evented for super::Queue {
-        fn register(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.tun.register(poll, token, interest, opts)
-        }
-
-        fn reregister(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.tun.reregister(poll, token, interest, opts)
-        }
-
-        fn deregister(&self, poll: &Poll) -> io::Result<()> {
-            self.tun.deregister(poll)
-        }
     }
 }

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -163,7 +163,7 @@ impl Device {
         self.queues[0].has_packet_information()
     }
 
-    #[cfg(feature = "mio")]
+    #[cfg(feature = "async")]
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.queues[0].set_nonblock()
     }
@@ -391,7 +391,7 @@ impl Queue {
         self.pi_enabled
     }
 
-    #[cfg(feature = "mio")]
+    #[cfg(feature = "async")]
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.tun.set_nonblock()
     }
@@ -430,65 +430,6 @@ impl Into<c_short> for Layer {
         match self {
             Layer::L2 => IFF_TAP,
             Layer::L3 => IFF_TUN,
-        }
-    }
-}
-
-#[cfg(feature = "mio")]
-mod mio {
-    use mio::event::Evented;
-    use mio::{Poll, PollOpt, Ready, Token};
-    use std::io;
-
-    impl Evented for super::Device {
-        fn register(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.queues[0].register(poll, token, interest, opts)
-        }
-
-        fn reregister(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.queues[0].reregister(poll, token, interest, opts)
-        }
-
-        fn deregister(&self, poll: &Poll) -> io::Result<()> {
-            self.queues[0].deregister(poll)
-        }
-    }
-
-    impl Evented for super::Queue {
-        fn register(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.tun.register(poll, token, interest, opts)
-        }
-
-        fn reregister(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.tun.reregister(poll, token, interest, opts)
-        }
-
-        fn deregister(&self, poll: &Poll) -> io::Result<()> {
-            self.tun.deregister(poll)
         }
     }
 }

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -176,7 +176,7 @@ impl Device {
         self.queue.has_packet_information()
     }
 
-    #[cfg(feature = "mio")]
+    #[cfg(feature = "async")]
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.queue.set_nonblock()
     }
@@ -368,13 +368,13 @@ impl D for Device {
 
 impl AsRawFd for Device {
     fn as_raw_fd(&self) -> RawFd {
-        self.queue.tun.as_raw_fd()
+        self.queue.as_raw_fd()
     }
 }
 
 impl IntoRawFd for Device {
     fn into_raw_fd(self) -> RawFd {
-        self.queue.tun.into_raw_fd()
+        self.queue.into_raw_fd()
     }
 }
 
@@ -388,9 +388,21 @@ impl Queue {
         true
     }
 
-    #[cfg(feature = "mio")]
+    #[cfg(feature = "async")]
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.tun.set_nonblock()
+    }
+}
+
+impl AsRawFd for Queue {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tun.as_raw_fd()
+    }
+}
+
+impl IntoRawFd for Queue {
+    fn into_raw_fd(self) -> RawFd {
+        self.tun.into_raw_fd()
     }
 }
 
@@ -407,64 +419,5 @@ impl Write for Queue {
 
     fn flush(&mut self) -> io::Result<()> {
         self.tun.flush()
-    }
-}
-
-#[cfg(feature = "mio")]
-mod mio {
-    use mio::event::Evented;
-    use mio::{Poll, PollOpt, Ready, Token};
-    use std::io;
-
-    impl Evented for super::Device {
-        fn register(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.queue.register(poll, token, interest, opts)
-        }
-
-        fn reregister(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.queue.reregister(poll, token, interest, opts)
-        }
-
-        fn deregister(&self, poll: &Poll) -> io::Result<()> {
-            self.queue.deregister(poll)
-        }
-    }
-
-    impl Evented for super::Queue {
-        fn register(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.tun.register(poll, token, interest, opts)
-        }
-
-        fn reregister(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            self.tun.reregister(poll, token, interest, opts)
-        }
-
-        fn deregister(&self, poll: &Poll) -> io::Result<()> {
-            self.tun.deregister(poll)
-        }
     }
 }

--- a/src/platform/posix/fd.rs
+++ b/src/platform/posix/fd.rs
@@ -18,7 +18,7 @@ use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use crate::error::*;
 use libc::{self, fcntl, F_SETFL, O_NONBLOCK};
 
-/// POSIX file descriptor support for `io` traits and optionally for `mio`.
+/// POSIX file descriptor support for `io` traits.
 pub struct Fd(pub RawFd);
 
 impl Fd {
@@ -91,40 +91,6 @@ impl Drop for Fd {
             if self.0 >= 0 {
                 libc::close(self.0);
             }
-        }
-    }
-}
-
-#[cfg(feature = "mio")]
-mod mio {
-    use mio::event::Evented;
-    use mio::unix::EventedFd;
-    use mio::{Poll, PollOpt, Ready, Token};
-    use std::io;
-
-    impl Evented for super::Fd {
-        fn register(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            EventedFd(&self.0).register(poll, token, interest, opts)
-        }
-
-        fn reregister(
-            &self,
-            poll: &Poll,
-            token: Token,
-            interest: Ready,
-            opts: PollOpt,
-        ) -> io::Result<()> {
-            EventedFd(&self.0).reregister(poll, token, interest, opts)
-        }
-
-        fn deregister(&self, poll: &Poll) -> io::Result<()> {
-            EventedFd(&self.0).deregister(poll)
         }
     }
 }

--- a/src/platform/posix/sockaddr.rs
+++ b/src/platform/posix/sockaddr.rs
@@ -17,9 +17,9 @@ use std::net::Ipv4Addr;
 use std::ptr;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-use libc::{c_uchar, c_uint};
+use libc::c_uchar;
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use libc::{c_uint, c_ushort};
+use libc::c_ushort;
 
 use libc::AF_INET as _AF_INET;
 use libc::{in_addr, sockaddr, sockaddr_in};
@@ -64,7 +64,9 @@ impl From<Ipv4Addr> for SockAddr {
 
         addr.sin_family = AF_INET;
         addr.sin_port = 0;
-        addr.sin_addr = in_addr { s_addr: u32::from_ne_bytes(octets) };
+        addr.sin_addr = in_addr {
+            s_addr: u32::from_ne_bytes(octets),
+        };
 
         SockAddr(addr)
     }


### PR DESCRIPTION
Specifically this commit:

* Upgrades tokio to v1.x
* Updates all dependencies to their latest stable version
* Implements the async feature instead by tokio's AsyncFd
* Implements AsRawFd for types that need the async interface
* Removes all mio-related stuffs