### PR TITLE
add Requirements for using rust-tun

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@ TUN interfaces [![Crates.io](https://img.shields.io/crates/v/tun.svg)](https://c
 ==============
 This crate allows the creation and usage of TUN interfaces, the aim is to make this cross-platform.
 
+Requirements
+-----
+- nightly rust
+
 Usage
 -----
 First, add the following to your `Cargo.toml`:


### PR DESCRIPTION
Thanks to create this awesome crate!  
I tryed to use this crate in my project, but it's not worked in stable channel such as below.  

```toml
[dependencies]
tun = "0.3"
```

```shell
$ rustup show
Default host: x86_64-unknown-linux-gnu
rustup home:  ~/.rustup

stable-x86_64-unknown-linux-gnu (default)
rustc 1.50.0 (cb75ad5db 2021-02-10)
```

because `#![feature]` used in `src/lib.rs`.  
so I added a sentence that tells users should use rust-tun with nightly released rustc.  
