### PR TITLE
feat: Allow setting non-blocking mode without enabling async

### DIFF
--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -56,7 +56,7 @@ impl Device {
         self.queue.has_packet_information()
     }
 
-    #[cfg(feature = "async")]
+    /// Set non-blocking mode
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.queue.set_nonblock()
     }
@@ -164,7 +164,6 @@ impl Queue {
         false
     }
 
-    #[cfg(feature = "async")]
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.tun.set_nonblock()
     }

--- a/src/platform/ios/device.rs
+++ b/src/platform/ios/device.rs
@@ -56,7 +56,7 @@ impl Device {
         self.queue.has_packet_information()
     }
 
-    #[cfg(feature = "async")]
+    /// Set non-blocking mode
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.queue.set_nonblock()
     }
@@ -164,7 +164,6 @@ impl Queue {
         true
     }
 
-    #[cfg(feature = "async")]
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.tun.set_nonblock()
     }

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -163,7 +163,7 @@ impl Device {
         self.queues[0].has_packet_information()
     }
 
-    #[cfg(feature = "async")]
+    /// Set non-blocking mode
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.queues[0].set_nonblock()
     }
@@ -391,7 +391,6 @@ impl Queue {
         self.pi_enabled
     }
 
-    #[cfg(feature = "async")]
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.tun.set_nonblock()
     }

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -176,7 +176,7 @@ impl Device {
         self.queue.has_packet_information()
     }
 
-    #[cfg(feature = "async")]
+    /// Set non-blocking mode
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.queue.set_nonblock()
     }
@@ -388,7 +388,6 @@ impl Queue {
         true
     }
 
-    #[cfg(feature = "async")]
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.tun.set_nonblock()
     }

--- a/src/platform/posix/fd.rs
+++ b/src/platform/posix/fd.rs
@@ -16,7 +16,7 @@ use std::io::{self, Read, Write};
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 
 use crate::error::*;
-use libc::{self, fcntl, F_SETFL, O_NONBLOCK};
+use libc::{self, fcntl, F_GETFL, F_SETFL, O_NONBLOCK};
 
 /// POSIX file descriptor support for `io` traits.
 pub struct Fd(pub RawFd);
@@ -32,7 +32,7 @@ impl Fd {
 
     /// Enable non-blocking mode
     pub fn set_nonblock(&self) -> io::Result<()> {
-        match unsafe { fcntl(self.0, F_SETFL, O_NONBLOCK) } {
+        match unsafe { fcntl(self.0, F_SETFL, fcntl(self.0, F_GETFL) | O_NONBLOCK) } {
             0 => Ok(()),
             _ => Err(io::Error::last_os_error()),
         }


### PR DESCRIPTION
Non-blocking mode shouldn't be bound with `async`.