### PR TITLE
OpenBSD support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["tun", "network", "tunnel", "bindings"]
 libc = "0.2"
 thiserror = "1"
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "openbsd", target_os = "ios"))'.dependencies]
 tokio = { version = "1", features = ["net", "macros"], optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 bytes = { version = "1", optional = true }
@@ -22,8 +22,8 @@ byteorder = { version = "1", optional = true }
 # This is only for the `ready` macro.
 futures-core = { version = "0.3", optional = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-ioctl = { version = "0.6", package = "ioctl-sys" }
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os="openbsd"))'.dependencies]
+ioctl = { version = "0.7", package = "ioctl-sys", git = "https://github.com/hargoniX/ioctl" }
 
 [dev-dependencies]
 packet = "0.1"

--- a/src/async/codec.rs
+++ b/src/async/codec.rs
@@ -40,7 +40,7 @@ impl PacketProtocol {
         }
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "openbsd", target_os = "ios"))]
     fn into_pi_field(&self) -> Result<u16, io::Error> {
         match self {
             PacketProtocol::IPv4 => Ok(libc::PF_INET as u16),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub use crate::platform::create;
     any(
         target_os = "linux",
         target_os = "macos",
+        target_os = "openbsd",
         target_os = "ios",
         target_os = "android"
     )
@@ -42,6 +43,7 @@ pub mod r#async;
     any(
         target_os = "linux",
         target_os = "macos",
+        target_os = "openbsd",
         target_os = "ios",
         target_os = "android"
     )

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -27,6 +27,11 @@ pub mod macos;
 #[cfg(target_os = "macos")]
 pub use self::macos::{create, Configuration, Device, Queue};
 
+#[cfg(target_os = "openbsd")]
+pub mod openbsd;
+#[cfg(target_os = "openbsd")]
+pub use self::openbsd::{create, Configuration, Device, Queue};
+
 #[cfg(target_os = "ios")]
 pub mod ios;
 #[cfg(target_os = "ios")]

--- a/src/platform/openbsd/device.rs
+++ b/src/platform/openbsd/device.rs
@@ -1,0 +1,438 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+#![allow(unused_variables)]
+
+use std::ffi::CStr;
+use std::io::{self, Read, Write};
+use std::mem;
+use std::net::Ipv4Addr;
+use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
+use std::ptr;
+use std::sync::Arc;
+
+use libc;
+use libc::{c_char, c_uint, c_void, sockaddr, socklen_t, AF_INET, SOCK_DGRAM};
+
+use crate::configuration::{Configuration, Layer};
+use crate::device::Device as D;
+use crate::error::*;
+use crate::platform::openbsd::sys::*;
+use crate::platform::posix::{self, Fd, SockAddr};
+
+/// A TUN device using the TUN macOS driver.
+pub struct Device {
+    name: String,
+    queue: Queue,
+    ctl: Fd,
+}
+
+impl Device {
+    /// Create a new `Device` for the given `Configuration`.
+    pub fn new(config: &Configuration) -> Result<Self> {
+        let id = if let Some(name) = config.name.as_ref() {
+            if name.len() > IFNAMSIZ {
+                return Err(Error::NameTooLong);
+            }
+
+            if !name.starts_with("utun") {
+                return Err(Error::InvalidName);
+            }
+
+            name[4..].parse()?
+        } else {
+            0
+        };
+
+        if config.layer.filter(|l| *l != Layer::L3).is_some() {
+            return Err(Error::UnsupportedLayer);
+        }
+
+        let queues_number = config.queues.unwrap_or(1);
+        if queues_number != 1 {
+            return Err(Error::InvalidQueuesNumber);
+        }
+
+        let mut device = unsafe {
+            let tun = Fd::new(libc::socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL))
+                .map_err(|_| io::Error::last_os_error())?;
+
+            let mut info = ctl_info {
+                ctl_id: 0,
+                ctl_name: {
+                    let mut buffer = [0; 96];
+                    for (i, o) in UTUN_CONTROL_NAME.as_bytes().iter().zip(buffer.iter_mut()) {
+                        *o = *i as _;
+                    }
+                    buffer
+                },
+            };
+
+            if ctliocginfo(tun.0, &mut info as *mut _ as *mut _) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            let addr = sockaddr_ctl {
+                sc_id: info.ctl_id,
+                sc_len: mem::size_of::<sockaddr_ctl>() as _,
+                sc_family: AF_SYSTEM,
+                ss_sysaddr: AF_SYS_CONTROL,
+                sc_unit: id as c_uint,
+                sc_reserved: [0; 5],
+            };
+
+            if libc::connect(
+                tun.0,
+                &addr as *const sockaddr_ctl as *const sockaddr,
+                mem::size_of_val(&addr) as socklen_t,
+            ) < 0
+            {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            let mut name = [0u8; 64];
+            let mut name_len: socklen_t = 64;
+
+            if libc::getsockopt(
+                tun.0,
+                SYSPROTO_CONTROL,
+                UTUN_OPT_IFNAME,
+                &mut name as *mut _ as *mut c_void,
+                &mut name_len as *mut socklen_t,
+            ) < 0
+            {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            let ctl = Fd::new(libc::socket(AF_INET, SOCK_DGRAM, 0))
+                .map_err(|_| io::Error::last_os_error())?;
+
+            Device {
+                name: CStr::from_ptr(name.as_ptr() as *const c_char)
+                    .to_string_lossy()
+                    .into(),
+                queue: Queue { tun: tun },
+                ctl: ctl,
+            }
+        };
+
+        device.configure(&config)?;
+
+        Ok(device)
+    }
+
+    /// Prepare a new request.
+    pub unsafe fn request(&self) -> ifreq {
+        let mut req: ifreq = mem::zeroed();
+        ptr::copy_nonoverlapping(
+            self.name.as_ptr() as *const c_char,
+            req.ifrn.name.as_mut_ptr(),
+            self.name.len(),
+        );
+
+        req
+    }
+
+    /// Set the IPv4 alias of the device.
+    pub fn set_alias(&mut self, addr: Ipv4Addr, broadaddr: Ipv4Addr, mask: Ipv4Addr) -> Result<()> {
+        unsafe {
+            let mut req: ifaliasreq = mem::zeroed();
+            ptr::copy_nonoverlapping(
+                self.name.as_ptr() as *const c_char,
+                req.ifran.as_mut_ptr(),
+                self.name.len(),
+            );
+
+            req.addr = SockAddr::from(addr).into();
+            req.broadaddr = SockAddr::from(broadaddr).into();
+            req.mask = SockAddr::from(mask).into();
+
+            if siocaifaddr(self.ctl.as_raw_fd(), &req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            Ok(())
+        }
+    }
+
+    /// Split the interface into a `Reader` and `Writer`.
+    pub fn split(self) -> (posix::Reader, posix::Writer) {
+        let fd = Arc::new(self.queue.tun);
+        (posix::Reader(fd.clone()), posix::Writer(fd.clone()))
+    }
+
+    /// Return whether the device has packet information
+    pub fn has_packet_information(&self) -> bool {
+        self.queue.has_packet_information()
+    }
+
+    /// Set non-blocking mode
+    pub fn set_nonblock(&self) -> io::Result<()> {
+        self.queue.set_nonblock()
+    }
+}
+
+impl Read for Device {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.queue.tun.read(buf)
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        self.queue.tun.read_vectored(bufs)
+    }
+}
+
+impl Write for Device {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.queue.tun.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.queue.tun.flush()
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.queue.tun.write_vectored(bufs)
+    }
+}
+
+impl D for Device {
+    type Queue = Queue;
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    // XXX: Cannot set interface name on Darwin.
+    fn set_name(&mut self, value: &str) -> Result<()> {
+        Err(Error::InvalidName)
+    }
+
+    fn enabled(&mut self, value: bool) -> Result<()> {
+        unsafe {
+            let mut req = self.request();
+
+            if siocgifflags(self.ctl.as_raw_fd(), &mut req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            if value {
+                req.ifru.flags |= IFF_UP | IFF_RUNNING;
+            } else {
+                req.ifru.flags &= !IFF_UP;
+            }
+
+            if siocsifflags(self.ctl.as_raw_fd(), &req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            Ok(())
+        }
+    }
+
+    fn address(&self) -> Result<Ipv4Addr> {
+        unsafe {
+            let mut req = self.request();
+
+            if siocgifaddr(self.ctl.as_raw_fd(), &mut req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            SockAddr::new(&req.ifru.addr).map(Into::into)
+        }
+    }
+
+    fn set_address(&mut self, value: Ipv4Addr) -> Result<()> {
+        unsafe {
+            let mut req = self.request();
+            req.ifru.addr = SockAddr::from(value).into();
+
+            if siocsifaddr(self.ctl.as_raw_fd(), &req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            Ok(())
+        }
+    }
+
+    fn destination(&self) -> Result<Ipv4Addr> {
+        unsafe {
+            let mut req = self.request();
+
+            if siocgifdstaddr(self.ctl.as_raw_fd(), &mut req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            SockAddr::new(&req.ifru.dstaddr).map(Into::into)
+        }
+    }
+
+    fn set_destination(&mut self, value: Ipv4Addr) -> Result<()> {
+        unsafe {
+            let mut req = self.request();
+            req.ifru.dstaddr = SockAddr::from(value).into();
+
+            if siocsifdstaddr(self.ctl.as_raw_fd(), &req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            Ok(())
+        }
+    }
+
+    fn broadcast(&self) -> Result<Ipv4Addr> {
+        unsafe {
+            let mut req = self.request();
+
+            if siocgifbrdaddr(self.ctl.as_raw_fd(), &mut req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            SockAddr::new(&req.ifru.broadaddr).map(Into::into)
+        }
+    }
+
+    fn set_broadcast(&mut self, value: Ipv4Addr) -> Result<()> {
+        unsafe {
+            let mut req = self.request();
+            req.ifru.broadaddr = SockAddr::from(value).into();
+
+            if siocsifbrdaddr(self.ctl.as_raw_fd(), &req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            Ok(())
+        }
+    }
+
+    fn netmask(&self) -> Result<Ipv4Addr> {
+        unsafe {
+            let mut req = self.request();
+
+            if siocgifnetmask(self.ctl.as_raw_fd(), &mut req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            SockAddr::unchecked(&req.ifru.addr).map(Into::into)
+        }
+    }
+
+    fn set_netmask(&mut self, value: Ipv4Addr) -> Result<()> {
+        unsafe {
+            let mut req = self.request();
+            req.ifru.addr = SockAddr::from(value).into();
+
+            if siocsifnetmask(self.ctl.as_raw_fd(), &req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            Ok(())
+        }
+    }
+
+    fn mtu(&self) -> Result<i32> {
+        unsafe {
+            let mut req = self.request();
+
+            if siocgifmtu(self.ctl.as_raw_fd(), &mut req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            Ok(req.ifru.mtu)
+        }
+    }
+
+    fn set_mtu(&mut self, value: i32) -> Result<()> {
+        unsafe {
+            let mut req = self.request();
+            req.ifru.mtu = value;
+
+            if siocsifmtu(self.ctl.as_raw_fd(), &req) < 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+
+            Ok(())
+        }
+    }
+
+    fn queue(&mut self, index: usize) -> Option<&mut Self::Queue> {
+        if index > 0 {
+            return None;
+        }
+
+        Some(&mut self.queue)
+    }
+}
+
+impl AsRawFd for Device {
+    fn as_raw_fd(&self) -> RawFd {
+        self.queue.as_raw_fd()
+    }
+}
+
+impl IntoRawFd for Device {
+    fn into_raw_fd(self) -> RawFd {
+        self.queue.into_raw_fd()
+    }
+}
+
+pub struct Queue {
+    tun: Fd,
+}
+
+impl Queue {
+    pub fn has_packet_information(&self) -> bool {
+        // on openbsd this is always the case
+        true
+    }
+
+    pub fn set_nonblock(&self) -> io::Result<()> {
+        self.tun.set_nonblock()
+    }
+}
+
+impl AsRawFd for Queue {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tun.as_raw_fd()
+    }
+}
+
+impl IntoRawFd for Queue {
+    fn into_raw_fd(self) -> RawFd {
+        self.tun.into_raw_fd()
+    }
+}
+
+impl Read for Queue {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.tun.read(buf)
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        self.tun.read_vectored(bufs)
+    }
+}
+
+impl Write for Queue {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.tun.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.tun.flush()
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.tun.write_vectored(bufs)
+    }
+}

--- a/src/platform/openbsd/mod.rs
+++ b/src/platform/openbsd/mod.rs
@@ -1,0 +1,32 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+//! macOS specific functionality.
+
+pub mod sys;
+
+mod device;
+pub use self::device::{Device, Queue};
+
+use crate::configuration::Configuration as C;
+use crate::error::*;
+
+/// macOS-only interface configuration.
+#[derive(Copy, Clone, Default, Debug)]
+pub struct Configuration {}
+
+/// Create a TUN device with the given name.
+pub fn create(configuration: &C) -> Result<Device> {
+    Device::new(&configuration)
+}

--- a/src/platform/openbsd/mod.rs
+++ b/src/platform/openbsd/mod.rs
@@ -12,7 +12,7 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-//! macOS specific functionality.
+//! OpenBSD specific functionality.
 
 pub mod sys;
 
@@ -22,7 +22,7 @@ pub use self::device::{Device, Queue};
 use crate::configuration::Configuration as C;
 use crate::error::*;
 
-/// macOS-only interface configuration.
+/// OpenBSD-only interface configuration. (empty)
 #[derive(Copy, Clone, Default, Debug)]
 pub struct Configuration {}
 

--- a/src/platform/openbsd/sys.rs
+++ b/src/platform/openbsd/sys.rs
@@ -1,0 +1,138 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+//! Bindings to internal macOS stuff.
+
+use ioctl::*;
+use libc::sockaddr;
+use libc::{c_char, c_int, c_short, c_uint, c_ushort, c_void};
+
+pub const IFNAMSIZ: usize = 16;
+
+pub const IFF_UP: c_short = 0x1;
+pub const IFF_RUNNING: c_short = 0x40;
+
+pub const AF_SYS_CONTROL: c_ushort = 2;
+pub const AF_SYSTEM: c_char = 32;
+pub const PF_SYSTEM: c_int = AF_SYSTEM as c_int;
+pub const SYSPROTO_CONTROL: c_int = 2;
+pub const UTUN_OPT_IFNAME: c_int = 2;
+pub const UTUN_CONTROL_NAME: &str = "com.apple.net.utun_control";
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ctl_info {
+    pub ctl_id: c_uint,
+    pub ctl_name: [c_char; 96],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct sockaddr_ctl {
+    pub sc_len: c_char,
+    pub sc_family: c_char,
+    pub ss_sysaddr: c_ushort,
+    pub sc_id: c_uint,
+    pub sc_unit: c_uint,
+    pub sc_reserved: [c_uint; 5],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union ifrn {
+    pub name: [c_char; IFNAMSIZ],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ifdevmtu {
+    pub current: c_int,
+    pub min: c_int,
+    pub max: c_int,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union ifku {
+    pub ptr: *mut c_void,
+    pub value: c_int,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ifkpi {
+    pub module_id: c_uint,
+    pub type_: c_uint,
+    pub ifku: ifku,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union ifru {
+    pub addr: sockaddr,
+    pub dstaddr: sockaddr,
+    pub broadaddr: sockaddr,
+
+    pub flags: c_short,
+    pub metric: c_int,
+    pub mtu: c_int,
+    pub phys: c_int,
+    pub media: c_int,
+    pub intval: c_int,
+    pub data: *mut c_void,
+    pub devmtu: ifdevmtu,
+    pub wake_flags: c_uint,
+    pub route_refcnt: c_uint,
+    pub cap: [c_int; 2],
+    pub functional_type: c_uint,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ifreq {
+    pub ifrn: ifrn,
+    pub ifru: ifru,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ifaliasreq {
+    pub ifran: [c_char; IFNAMSIZ],
+    pub addr: sockaddr,
+    pub broadaddr: sockaddr,
+    pub mask: sockaddr,
+}
+
+ioctl!(readwrite ctliocginfo with 'N', 3; ctl_info);
+
+ioctl!(write siocsifflags with 'i', 16; ifreq);
+ioctl!(readwrite siocgifflags with 'i', 17; ifreq);
+
+ioctl!(write siocsifaddr with 'i', 12; ifreq);
+ioctl!(readwrite siocgifaddr with 'i', 33; ifreq);
+
+ioctl!(write siocsifdstaddr with 'i', 14; ifreq);
+ioctl!(readwrite siocgifdstaddr with 'i', 34; ifreq);
+
+ioctl!(write siocsifbrdaddr with 'i', 19; ifreq);
+ioctl!(readwrite siocgifbrdaddr with 'i', 35; ifreq);
+
+ioctl!(write siocsifnetmask with 'i', 22; ifreq);
+ioctl!(readwrite siocgifnetmask with 'i', 37; ifreq);
+
+ioctl!(write siocsifmtu with 'i', 52; ifreq);
+ioctl!(readwrite siocgifmtu with 'i', 51; ifreq);
+
+ioctl!(write siocaifaddr with 'i', 26; ifaliasreq);
+ioctl!(write siocdifaddr with 'i', 25; ifreq);

--- a/src/platform/openbsd/sys.rs
+++ b/src/platform/openbsd/sys.rs
@@ -12,70 +12,16 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-//! Bindings to internal macOS stuff.
+//! Bindings to internal OpenBSD stuff.
 
 use ioctl::*;
 use libc::sockaddr;
-use libc::{c_char, c_int, c_short, c_uint, c_ushort, c_void};
+use libc::{c_char, c_int, c_short, c_uint};
 
 pub const IFNAMSIZ: usize = 16;
 
 pub const IFF_UP: c_short = 0x1;
 pub const IFF_RUNNING: c_short = 0x40;
-
-pub const AF_SYS_CONTROL: c_ushort = 2;
-pub const AF_SYSTEM: c_char = 32;
-pub const PF_SYSTEM: c_int = AF_SYSTEM as c_int;
-pub const SYSPROTO_CONTROL: c_int = 2;
-pub const UTUN_OPT_IFNAME: c_int = 2;
-pub const UTUN_CONTROL_NAME: &str = "com.apple.net.utun_control";
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct ctl_info {
-    pub ctl_id: c_uint,
-    pub ctl_name: [c_char; 96],
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sockaddr_ctl {
-    pub sc_len: c_char,
-    pub sc_family: c_char,
-    pub ss_sysaddr: c_ushort,
-    pub sc_id: c_uint,
-    pub sc_unit: c_uint,
-    pub sc_reserved: [c_uint; 5],
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union ifrn {
-    pub name: [c_char; IFNAMSIZ],
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct ifdevmtu {
-    pub current: c_int,
-    pub min: c_int,
-    pub max: c_int,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union ifku {
-    pub ptr: *mut c_void,
-    pub value: c_int,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct ifkpi {
-    pub module_id: c_uint,
-    pub type_: c_uint,
-    pub ifku: ifku,
-}
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -86,53 +32,38 @@ pub union ifru {
 
     pub flags: c_short,
     pub metric: c_int,
-    pub mtu: c_int,
-    pub phys: c_int,
-    pub media: c_int,
-    pub intval: c_int,
-    pub data: *mut c_void,
-    pub devmtu: ifdevmtu,
-    pub wake_flags: c_uint,
-    pub route_refcnt: c_uint,
-    pub cap: [c_int; 2],
-    pub functional_type: c_uint,
+    pub vnetid: i64,
+    pub media: u64,
+    pub index: c_uint,
+    // caddr_t ifru_data is missing
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct ifreq {
-    pub ifrn: ifrn,
+    pub name: [c_char; IFNAMSIZ],
     pub ifru: ifru,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct ifaliasreq {
-    pub ifran: [c_char; IFNAMSIZ],
+    pub name: [c_char; IFNAMSIZ],
     pub addr: sockaddr,
-    pub broadaddr: sockaddr,
+    pub dstaddr: sockaddr,
     pub mask: sockaddr,
 }
-
-ioctl!(readwrite ctliocginfo with 'N', 3; ctl_info);
 
 ioctl!(write siocsifflags with 'i', 16; ifreq);
 ioctl!(readwrite siocgifflags with 'i', 17; ifreq);
 
-ioctl!(write siocsifaddr with 'i', 12; ifreq);
 ioctl!(readwrite siocgifaddr with 'i', 33; ifreq);
 
-ioctl!(write siocsifdstaddr with 'i', 14; ifreq);
 ioctl!(readwrite siocgifdstaddr with 'i', 34; ifreq);
 
-ioctl!(write siocsifbrdaddr with 'i', 19; ifreq);
-ioctl!(readwrite siocgifbrdaddr with 'i', 35; ifreq);
-
-ioctl!(write siocsifnetmask with 'i', 22; ifreq);
 ioctl!(readwrite siocgifnetmask with 'i', 37; ifreq);
 
-ioctl!(write siocsifmtu with 'i', 52; ifreq);
-ioctl!(readwrite siocgifmtu with 'i', 51; ifreq);
+ioctl!(write siocsifmtu with 'i', 127; ifreq);
+ioctl!(readwrite siocgifmtu with 'i', 126; ifreq);
 
 ioctl!(write siocaifaddr with 'i', 26; ifaliasreq);
-ioctl!(write siocdifaddr with 'i', 25; ifreq);

--- a/src/platform/posix/sockaddr.rs
+++ b/src/platform/posix/sockaddr.rs
@@ -68,6 +68,13 @@ impl From<Ipv4Addr> for SockAddr {
             s_addr: u32::from_ne_bytes(octets),
         };
 
+        // OpenBSD explicitly checks for this sin_len field and will
+        // fail if it is not provided properly.
+        #[cfg(target_os = "openbsd")]
+        {
+            addr.sin_len = mem::size_of::<sockaddr_in>() as u8;
+        }
+
         SockAddr(addr)
     }
 }

--- a/src/platform/posix/sockaddr.rs
+++ b/src/platform/posix/sockaddr.rs
@@ -16,7 +16,7 @@ use std::mem;
 use std::net::Ipv4Addr;
 use std::ptr;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "openbsd", target_os = "ios"))]
 use libc::c_uchar;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use libc::c_ushort;
@@ -33,7 +33,7 @@ pub struct SockAddr(sockaddr_in);
 #[cfg(any(target_os = "linux", target_os = "android"))]
 const AF_INET: c_ushort = _AF_INET as c_ushort;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "openbsd", target_os = "ios"))]
 const AF_INET: c_uchar = _AF_INET as c_uchar;
 
 impl SockAddr {


### PR DESCRIPTION
This PR implements support for OpenBSD's tun/tap implementation.

It currently relies on a git version of ioctl since ioctl didn't have OpenBSD support either,
however the code should already be very much ready for review and can then be merged once
https://github.com/jmesmon/ioctl/pull/19 is merged and released.