### PR TITLE
fix: implement IntoRawFd for Queue properly

### DIFF
--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -438,7 +438,7 @@ impl AsRawFd for Queue {
 
 impl IntoRawFd for Queue {
     fn into_raw_fd(self) -> RawFd {
-        self.tun.as_raw_fd()
+        self.tun.into_raw_fd()
     }
 }
 


### PR DESCRIPTION
as_raw_fd() will not transfer the ownership of fd to the caller :)