### PR TITLE
"async" feature deps enables for "android"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["tun", "network", "tunnel", "bindings"]
 libc = "0.2"
 thiserror = "1"
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "ios", target_os = "android"))'.dependencies]
 tokio = { version = "1", features = ["net", "macros"], optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 bytes = { version = "1", optional = true }


### PR DESCRIPTION
ref shadowsocks/shadowsocks-rust#856

https://github.com/meh/rust-tun/blob/b60d4c2ce9aa0b7518fc259c914a0459a5320888/src/lib.rs#L30-L38

The `async` mod could be enabled for "android", but the dependencies' cfg missed `target_os = "android"`