### PR TITLE
feat: add TunPacket::into_bytes()

### DIFF
--- a/src/async/codec.rs
+++ b/src/async/codec.rs
@@ -77,6 +77,10 @@ impl TunPacket {
     pub fn get_bytes(&self) -> &[u8] {
         &self.1
     }
+
+    pub fn into_bytes(self) -> Bytes {
+        self.1
+    }
 }
 
 /// A TunPacket Encoder/Decoder.


### PR DESCRIPTION
This comment add a function TunPacket::into_bytes() to struct TunPacket, which allows users to consume `TunPacket` and return the inner `Bytes` instences.

Thus we can avoid copy in the following code:
```rust
let bytes = Bytes::from(packet.get_bytes().to_owned())
```