### PR TITLE
add raw_fd_auto_close option by use raw_fd

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -46,6 +46,7 @@ pub struct Configuration {
     pub(crate) layer: Option<Layer>,
     pub(crate) queues: Option<usize>,
     pub(crate) raw_fd: Option<RawFd>,
+    pub(crate) raw_fd_auto_close: Option<bool>,
 }
 
 impl Configuration {
@@ -119,8 +120,9 @@ impl Configuration {
     }
 
     /// Set the raw fd.
-    pub fn raw_fd(&mut self, fd: RawFd) -> &mut Self {
+    pub fn raw_fd(&mut self, fd: RawFd, auto_close: bool) -> &mut Self {
         self.raw_fd = Some(fd);
+        self.raw_fd_auto_close = Some(auto_close);
         self
     }
 }

--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -35,8 +35,9 @@ impl Device {
             Some(raw_fd) => raw_fd,
             _ => return Err(Error::InvalidConfig),
         };
+        let auto_close = config.raw_fd_auto_close.unwrap_or(true);
         let device = {
-            let tun = Fd::new(fd).map_err(|_| io::Error::last_os_error())?;
+            let tun = Fd::new_with_auto(fd, auto_close).map_err(|_| io::Error::last_os_error())?;
 
             Device {
                 queue: Queue { tun: tun },

--- a/src/platform/ios/device.rs
+++ b/src/platform/ios/device.rs
@@ -35,8 +35,9 @@ impl Device {
             Some(raw_fd) => raw_fd,
             _ => return Err(Error::InvalidConfig),
         };
+        let auto_close = config.raw_fd_auto_close.unwrap_or(true);
         let mut device = unsafe {
-            let tun = Fd::new(fd).map_err(|_| io::Error::last_os_error())?;
+            let tun = Fd::new_with_auto(fd, auto_close).map_err(|_| io::Error::last_os_error())?;
 
             Device {
                 queue: Queue { tun: tun },


### PR DESCRIPTION
In Android 11,  Android enforced enable fdsan, close fd in rust is not allowed,  add a option to prevent auto close `fd`.