### PR TITLE
feat: improving async and sync API

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -61,13 +61,13 @@ impl<'a> IntoAddress for &'a str {
 
 impl IntoAddress for String {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (&**self).into_address()
+        (**self).into_address()
     }
 }
 
 impl<'a> IntoAddress for &'a String {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (&**self).into_address()
+        (**self).into_address()
     }
 }
 
@@ -79,7 +79,7 @@ impl IntoAddress for Ipv4Addr {
 
 impl<'a> IntoAddress for &'a Ipv4Addr {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (&**self).into_address()
+        (**self).into_address()
     }
 }
 
@@ -95,7 +95,7 @@ impl IntoAddress for IpAddr {
 
 impl<'a> IntoAddress for &'a IpAddr {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (&**self).into_address()
+        (**self).into_address()
     }
 }
 
@@ -107,7 +107,7 @@ impl IntoAddress for SocketAddrV4 {
 
 impl<'a> IntoAddress for &'a SocketAddrV4 {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (&**self).into_address()
+        (**self).into_address()
     }
 }
 
@@ -123,6 +123,6 @@ impl IntoAddress for SocketAddr {
 
 impl<'a> IntoAddress for &'a SocketAddr {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (&**self).into_address()
+        (**self).into_address()
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -61,13 +61,13 @@ impl<'a> IntoAddress for &'a str {
 
 impl IntoAddress for String {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (**self).into_address()
+        self.as_str().into_address()
     }
 }
 
 impl<'a> IntoAddress for &'a String {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (**self).into_address()
+        self.as_str().into_address()
     }
 }
 
@@ -79,13 +79,13 @@ impl IntoAddress for Ipv4Addr {
 
 impl<'a> IntoAddress for &'a Ipv4Addr {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (**self).into_address()
+        (*self).into_address()
     }
 }
 
 impl IntoAddress for IpAddr {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        match *self {
+        match self {
             IpAddr::V4(ref value) => Ok(*value),
 
             IpAddr::V6(_) => Err(Error::InvalidAddress),
@@ -95,7 +95,7 @@ impl IntoAddress for IpAddr {
 
 impl<'a> IntoAddress for &'a IpAddr {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (**self).into_address()
+        (*self).into_address()
     }
 }
 
@@ -107,13 +107,13 @@ impl IntoAddress for SocketAddrV4 {
 
 impl<'a> IntoAddress for &'a SocketAddrV4 {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (**self).into_address()
+        (*self).into_address()
     }
 }
 
 impl IntoAddress for SocketAddr {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        match *self {
+        match self {
             SocketAddr::V4(ref value) => Ok(*value.ip()),
 
             SocketAddr::V6(_) => Err(Error::InvalidAddress),
@@ -123,6 +123,6 @@ impl IntoAddress for SocketAddr {
 
 impl<'a> IntoAddress for &'a SocketAddr {
     fn into_address(&self) -> Result<Ipv4Addr> {
-        (**self).into_address()
+        (*self).into_address()
     }
 }

--- a/src/async/device.rs
+++ b/src/async/device.rs
@@ -59,12 +59,13 @@ impl AsyncDevice {
 
 impl AsyncRead for AsyncDevice {
     fn poll_read(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut ReadBuf,
     ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
         loop {
-            let mut guard = ready!(self.inner.poll_read_ready_mut(cx))?;
+            let mut guard = ready!(this.inner.poll_read_ready_mut(cx))?;
             let rbuf = buf.initialize_unfilled();
             match guard.try_io(|inner| inner.get_mut().read(rbuf)) {
                 Ok(res) => return Poll::Ready(res.map(|n| buf.advance(n))),
@@ -76,12 +77,13 @@ impl AsyncRead for AsyncDevice {
 
 impl AsyncWrite for AsyncDevice {
     fn poll_write(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
         loop {
-            let mut guard = ready!(self.inner.poll_write_ready_mut(cx))?;
+            let mut guard = ready!(this.inner.poll_write_ready_mut(cx))?;
             match guard.try_io(|inner| inner.get_mut().write(buf)) {
                 Ok(res) => return Poll::Ready(res),
                 Err(_wb) => continue,
@@ -104,12 +106,13 @@ impl AsyncWrite for AsyncDevice {
     }
 
     fn poll_write_vectored(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<Result<usize, io::Error>> {
+        let this = self.get_mut();
         loop {
-            let mut guard = ready!(self.inner.poll_write_ready_mut(cx))?;
+            let mut guard = ready!(this.inner.poll_write_ready_mut(cx))?;
             match guard.try_io(|inner| inner.get_mut().write_vectored(bufs)) {
                 Ok(res) => return Poll::Ready(res),
                 Err(_wb) => continue,
@@ -155,12 +158,13 @@ impl AsyncQueue {
 
 impl AsyncRead for AsyncQueue {
     fn poll_read(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut ReadBuf,
     ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
         loop {
-            let mut guard = ready!(self.inner.poll_read_ready_mut(cx))?;
+            let mut guard = ready!(this.inner.poll_read_ready_mut(cx))?;
             let rbuf = buf.initialize_unfilled();
             match guard.try_io(|inner| inner.get_mut().read(rbuf)) {
                 Ok(res) => return Poll::Ready(res.map(|n| buf.advance(n))),
@@ -172,12 +176,13 @@ impl AsyncRead for AsyncQueue {
 
 impl AsyncWrite for AsyncQueue {
     fn poll_write(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
         loop {
-            let mut guard = ready!(self.inner.poll_write_ready_mut(cx))?;
+            let mut guard = ready!(this.inner.poll_write_ready_mut(cx))?;
             match guard.try_io(|inner| inner.get_mut().write(buf)) {
                 Ok(res) => return Poll::Ready(res),
                 Err(_wb) => continue,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -19,16 +19,11 @@ use crate::address::IntoAddress;
 use crate::platform;
 
 /// TUN interface OSI layer of operation.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
 pub enum Layer {
     L2,
+    #[default]
     L3,
-}
-
-impl Default for Layer {
-    fn default() -> Self {
-        Layer::L3
-    }
 }
 
 /// Configuration builder for a TUN interface.

--- a/src/device.rs
+++ b/src/device.rs
@@ -90,6 +90,12 @@ pub trait Device: Read + Write {
     /// Set the MTU.
     fn set_mtu(&mut self, value: i32) -> Result<()>;
 
-    /// Get a device queue.
-    fn queue(&mut self, index: usize) -> Option<&mut Self::Queue>;
+    /// Get a mutable reference to the device queue.
+    fn queue_mut(&mut self, index: usize) -> Option<&mut Self::Queue>;
+
+    /// Get a reference to the device queue.
+    fn queue(&self, index: usize) -> Option<&Self::Queue>;
+
+    /// Transforms this device into queues.
+    fn queues(self) -> Vec<Self::Queue>;
 }

--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -39,7 +39,7 @@ impl Device {
             let tun = Fd::new(fd).map_err(|_| io::Error::last_os_error())?;
 
             Device {
-                queue: Queue { tun: tun },
+                queue: Queue { tun },
             }
         };
         Ok(device)
@@ -141,12 +141,24 @@ impl D for Device {
         Ok(())
     }
 
-    fn queue(&mut self, index: usize) -> Option<&mut Self::Queue> {
+    fn queue_mut(&mut self, index: usize) -> Option<&mut Self::Queue> {
         if index > 0 {
             return None;
         }
 
         Some(&mut self.queue)
+    }
+
+    fn queue(&self, index: usize) -> Option<&Self::Queue> {
+        if index > 0 {
+            return None;
+        }
+
+        Some(&self.queue)
+    }
+
+    fn queues(self) -> Vec<Self::Queue> {
+        vec![self.queue]
     }
 }
 
@@ -163,7 +175,7 @@ impl IntoRawFd for Device {
 }
 
 pub struct Queue {
-    tun: Fd,
+    pub tun: Fd,
 }
 
 impl Queue {

--- a/src/platform/ios/device.rs
+++ b/src/platform/ios/device.rs
@@ -39,7 +39,7 @@ impl Device {
             let tun = Fd::new(fd).map_err(|_| io::Error::last_os_error())?;
 
             Device {
-                queue: Queue { tun: tun },
+                queue: Queue { tun },
             }
         };
         Ok(device)
@@ -141,12 +141,24 @@ impl D for Device {
         Ok(())
     }
 
-    fn queue(&mut self, index: usize) -> Option<&mut Self::Queue> {
+    fn queue_mut(&mut self, index: usize) -> Option<&mut Self::Queue> {
         if index > 0 {
             return None;
         }
 
         Some(&mut self.queue)
+    }
+
+    fn queue(&self, index: usize) -> Option<&Self::Queue> {
+        if index > 0 {
+            return None;
+        }
+
+        Some(&self.queue)
+    }
+
+    fn queues(self) -> Vec<Self::Queue> {
+        vec![self.queue]
     }
 }
 
@@ -163,7 +175,7 @@ impl IntoRawFd for Device {
 }
 
 pub struct Queue {
-    tun: Fd,
+    pub tun: Fd,
 }
 
 impl Queue {

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -372,8 +372,16 @@ impl D for Device {
         }
     }
 
-    fn queue(&mut self, index: usize) -> Option<&mut Self::Queue> {
+    fn queue_mut(&mut self, index: usize) -> Option<&mut Self::Queue> {
         self.queues.get_mut(index)
+    }
+
+    fn queue(&self, index: usize) -> Option<&Self::Queue> {
+        self.queues.get(index)
+    }
+
+    fn queues(self) -> Vec<Self::Queue> {
+        self.queues
     }
 }
 
@@ -392,7 +400,7 @@ impl IntoRawFd for Device {
 }
 
 pub struct Queue {
-    tun: Fd,
+    pub tun: Fd,
     pi_enabled: bool,
 }
 

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -121,12 +121,12 @@ impl Device {
                 name: CStr::from_ptr(name.as_ptr() as *const c_char)
                     .to_string_lossy()
                     .into(),
-                queue: Queue { tun: tun },
-                ctl: ctl,
+                queue: Queue { tun },
+                ctl,
             }
         };
 
-        device.configure(&config)?;
+        device.configure(config)?;
 
         Ok(device)
     }
@@ -168,7 +168,7 @@ impl Device {
     /// Split the interface into a `Reader` and `Writer`.
     pub fn split(self) -> (posix::Reader, posix::Writer) {
         let fd = Arc::new(self.queue.tun);
-        (posix::Reader(fd.clone()), posix::Writer(fd.clone()))
+        (posix::Reader(fd.clone()), posix::Writer(fd))
     }
 
     /// Return whether the device has packet information

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -126,7 +126,7 @@ impl Device {
             }
         };
 
-        device.configure(&config)?;
+        device.configure(config)?;
         device.set_alias(
             config.address.unwrap_or(Ipv4Addr::new(10, 0, 0, 1)),
             config.destination.unwrap_or(Ipv4Addr::new(10, 0, 0, 255)),

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -365,12 +365,24 @@ impl D for Device {
         }
     }
 
-    fn queue(&mut self, index: usize) -> Option<&mut Self::Queue> {
+    fn queue_mut(&mut self, index: usize) -> Option<&mut Self::Queue> {
         if index > 0 {
             return None;
         }
 
         Some(&mut self.queue)
+    }
+
+    fn queue(&self, index: usize) -> Option<&Self::Queue> {
+        if index > 0 {
+            return None;
+        }
+
+        Some(&self.queue)
+    }
+
+    fn queues(self) -> Vec<Self::Queue> {
+        vec![self.queue]
     }
 }
 
@@ -387,7 +399,7 @@ impl IntoRawFd for Device {
 }
 
 pub struct Queue {
-    tun: Fd,
+    pub tun: Fd,
 }
 
 impl Queue {

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -28,5 +28,5 @@ pub struct Configuration {}
 
 /// Create a TUN device with the given name.
 pub fn create(configuration: &C) -> Result<Device> {
-    Device::new(&configuration)
+    Device::new(configuration)
 }

--- a/src/platform/posix/fd.rs
+++ b/src/platform/posix/fd.rs
@@ -67,6 +67,38 @@ impl Read for Fd {
     }
 }
 
+impl Fd {
+    /// # Safety
+    ///
+    /// Concurrent writes can cause unexpected results.
+    pub unsafe fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        unsafe {
+            let amount = libc::write(self.0, buf.as_ptr() as *const _, buf.len());
+
+            if amount < 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(amount as usize)
+        }
+    }
+
+    /// # Safety
+    ///
+    /// Concurrent reads can cause unexpected results.
+    pub unsafe fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        unsafe {
+            let amount = libc::read(self.0, buf.as_mut_ptr() as *mut _, buf.len());
+
+            if amount < 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(amount as usize)
+        }
+    }
+}
+
 impl Write for Fd {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         unsafe {


### PR DESCRIPTION
This pull request will remove the requirement for obtaining an unnecessary mutable reference to self in AsyncRead and AsyncWrite, as it is already protected by locks within the code. It will also include methods like `send` and `recv` in the async API that can be used concurrently by only sharing a reference to the queue.

The method `queue` will be replaced by `queue_mut`, as it is intended to be. Additionally, two more methods will be added: `queue`, which returns a reference to the queue, and `queues`, which transmute the `device` to the vector of its queues.