### PR TITLE
Fix the issue of macos netmask setting

### DIFF
--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -127,6 +127,11 @@ impl Device {
         };
 
         device.configure(&config)?;
+        device.set_alias(
+            config.address.unwrap_or(Ipv4Addr::new(10, 0, 0, 1)),
+            config.destination.unwrap_or(Ipv4Addr::new(10, 0, 0, 255)),
+            config.netmask.unwrap_or(Ipv4Addr::new(255, 255, 255, 0)),
+        )?;
 
         Ok(device)
     }


### PR DESCRIPTION
Currently, you can't set the `netmask` in macos system. It will always be `netmask 0xff000000`, no matter what kind of netmask is given to the program.

Seems command `siocsifnetmask` doesn't work as expected. The fix tries to make another system call `siocaifaddr`, which was defined but not used.

Tophatting:

<img width="1226" alt="Screenshot 2023-02-08 at 14 15 27" src="https://user-images.githubusercontent.com/6628202/217460234-fffa24c7-917a-4083-9098-47a0ca53bd84.png">
