### PR TITLE
fix(macOS): sc_unit should be the number in name + 1

### DIFF
--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -49,7 +49,7 @@ impl Device {
                 return Err(Error::InvalidName);
             }
 
-            name[4..].parse()?
+            name[4..].parse()? + 1
         } else {
             0
         };


### PR DESCRIPTION
Current implementation, if you set `utun10` in `name`, then the actual `utun` device name is `utun9`. If the `name` is set to `utun0`, then it actually tells the kernel to dynamically allocate a free id for it.

ref https://github.com/shadowsocks/shadowsocks-rust/issues/1176