### PR TITLE
fix(deps): update tokio-utils to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "ios", target_os = "android"))'.dependencies]
 tokio = { version = "1", features = ["net", "macros"], optional = true }
-tokio-util = { version = "0.6", features = ["codec"], optional = true }
+tokio-util = { version = "0.7", features = ["codec"], optional = true }
 bytes = { version = "1", optional = true }
 byteorder = { version = "1", optional = true }
 # This is only for the `ready` macro.


### PR DESCRIPTION
There is an incompatibility of the `Framed` struct between versions 0.6 and 0.7 that prevents using them simultaneously.