### PR TITLE
Add split in platform::linux::Device again

### DIFF
--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -18,6 +18,7 @@ use std::mem;
 use std::net::Ipv4Addr;
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use std::ptr;
+use std::sync::Arc;
 use std::vec::Vec;
 
 use libc;
@@ -28,7 +29,7 @@ use crate::configuration::{Configuration, Layer};
 use crate::device::Device as D;
 use crate::error::*;
 use crate::platform::linux::sys::*;
-use crate::platform::posix::{Fd, SockAddr};
+use crate::platform::posix::{self, Fd, SockAddr};
 
 /// A TUN device using the TUN/TAP Linux driver.
 pub struct Device {
@@ -161,6 +162,12 @@ impl Device {
     /// Return whether the device has packet information
     pub fn has_packet_information(&mut self) -> bool {
         self.queues[0].has_packet_information()
+    }
+
+    /// Split the interface into a `Reader` and `Writer`.
+    pub fn split(mut self) -> (posix::Reader, posix::Writer) {
+        let fd = Arc::new(self.queues.swap_remove(0).tun);
+        (posix::Reader(fd.clone()), posix::Writer(fd.clone()))
     }
 
     /// Set non-blocking mode


### PR DESCRIPTION
before https://github.com/meh/rust-tun/pull/41 had been merged by [0e4ef622](https://github.com/0e4ef622), but removed somehow.
I just want to add it again.