### PR TITLE
Fix the error introduced by "fix(macOS): sc_unit should be the number in name + 1 "

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun"
-version = "0.5.5"
+version = "0.6.0"
 edition = "2021"
 
 authors = ["meh. <meh@schizofreni.co>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 authors = ["meh. <meh@schizofreni.co>"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ First, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tun = "0.6.1"
+tun = "0.6"
 ```
 
 Next, add this to your crate root:
@@ -21,7 +21,7 @@ If you want to use the TUN interface with mio/tokio, you need to enable the `asy
 
 ```toml
 [dependencies]
-tun = { version = "0.6.1", features = ["async"] }
+tun = { version = "0.6", features = ["async"] }
 ```
 
 Example

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ First, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tun = "0.5"
+tun = "0.6.1"
 ```
 
 Next, add this to your crate root:
@@ -21,7 +21,7 @@ If you want to use the TUN interface with mio/tokio, you need to enable the `asy
 
 ```toml
 [dependencies]
-tun = { version = "0.5", features = ["async"] }
+tun = { version = "0.6.1", features = ["async"] }
 ```
 
 Example
@@ -66,7 +66,8 @@ interfaces.
 
 macOS
 -----
-It just works, but you have to set up routing manually.
+It just works, but you have to set up routing manually. For example:
+> sudo route -n add -net 10.0.0.0/24 10.0.0.1
 
 iOS
 ----

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -49,7 +49,7 @@ impl Device {
                 return Err(Error::InvalidName);
             }
 
-            name[4..].parse::<u32>()? + 1u32
+            name[4..].parse::<u32>()?  + 1u32
         } else {
             0u32
         };

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -49,9 +49,9 @@ impl Device {
                 return Err(Error::InvalidName);
             }
 
-            name[4..].parse()? + 1
+            name[4..].parse::<u32>()? + 1u32
         } else {
-            0
+            0u32
         };
 
         if config.layer.filter(|l| *l != Layer::L3).is_some() {


### PR DESCRIPTION
The merged pull request uses `name[4..].parse()? + 1` in the `pub fn new(config: &Configuration) -> Result<Self>`, which makes the inferred type for the generic type of `parse` is `()`, which does not implement `add<i32>`. 
````
     |
52   |             name[4..].parse()? + 1
     |                       ^^^^^ the trait `FromStr` is not implemented for `()`
````

