### PR TITLE
feat: replace deprecated ioctl with nix (#86)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1", features = ["net", "macros"], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-ioctl = { version = "0.8", package = "ioctl-sys" }
+nix = { version = "0.27", features = ["ioctl"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wintun = { version = "0.3", features = ["panic_on_unsent_packets"] }

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -90,8 +90,8 @@ impl Device {
                 let tun = Fd::new(libc::open(b"/dev/net/tun\0".as_ptr() as *const _, O_RDWR))
                     .map_err(|_| io::Error::last_os_error())?;
 
-                if tunsetiff(tun.0, &mut req as *mut _ as *mut _) < 0 {
-                    return Err(io::Error::last_os_error().into());
+                if let Err(err) = tunsetiff(tun.0, &mut req as *mut _ as *mut _) {
+                    return Err(io::Error::from(err).into());
                 }
 
                 queues.push(Queue {
@@ -128,8 +128,8 @@ impl Device {
     /// Make the device persistent.
     pub fn persist(&mut self) -> Result<()> {
         unsafe {
-            if tunsetpersist(self.as_raw_fd(), &1) < 0 {
-                Err(io::Error::last_os_error().into())
+            if let Err(err) = tunsetpersist(self.as_raw_fd(), &1) {
+                Err(io::Error::from(err).into())
             } else {
                 Ok(())
             }
@@ -139,8 +139,8 @@ impl Device {
     /// Set the owner of the device.
     pub fn user(&mut self, value: i32) -> Result<()> {
         unsafe {
-            if tunsetowner(self.as_raw_fd(), &value) < 0 {
-                Err(io::Error::last_os_error().into())
+            if let Err(err) = tunsetowner(self.as_raw_fd(), &value) {
+                Err(io::Error::from(err).into())
             } else {
                 Ok(())
             }
@@ -150,8 +150,8 @@ impl Device {
     /// Set the group of the device.
     pub fn group(&mut self, value: i32) -> Result<()> {
         unsafe {
-            if tunsetgroup(self.as_raw_fd(), &value) < 0 {
-                Err(io::Error::last_os_error().into())
+            if let Err(err) = tunsetgroup(self.as_raw_fd(), &value) {
+                Err(io::Error::from(err).into())
             } else {
                 Ok(())
             }
@@ -221,8 +221,8 @@ impl D for Device {
                 value.len(),
             );
 
-            if siocsifname(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifname(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             self.name = value.into();
@@ -235,8 +235,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifflags(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifflags(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             if value {
@@ -245,8 +245,8 @@ impl D for Device {
                 req.ifr_ifru.ifru_flags &= !(IFF_UP as c_short);
             }
 
-            if siocsifflags(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifflags(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -257,8 +257,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifaddr(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifaddr(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             SockAddr::new(&req.ifr_ifru.ifru_addr).map(Into::into)
@@ -270,8 +270,8 @@ impl D for Device {
             let mut req = self.request();
             req.ifr_ifru.ifru_addr = SockAddr::from(value).into();
 
-            if siocsifaddr(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifaddr(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -282,8 +282,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifdstaddr(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifdstaddr(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             SockAddr::new(&req.ifr_ifru.ifru_dstaddr).map(Into::into)
@@ -295,8 +295,8 @@ impl D for Device {
             let mut req = self.request();
             req.ifr_ifru.ifru_dstaddr = SockAddr::from(value).into();
 
-            if siocsifdstaddr(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifdstaddr(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -307,8 +307,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifbrdaddr(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifbrdaddr(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             SockAddr::new(&req.ifr_ifru.ifru_broadaddr).map(Into::into)
@@ -320,8 +320,8 @@ impl D for Device {
             let mut req = self.request();
             req.ifr_ifru.ifru_broadaddr = SockAddr::from(value).into();
 
-            if siocsifbrdaddr(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifbrdaddr(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -332,8 +332,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifnetmask(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifnetmask(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             SockAddr::new(&req.ifr_ifru.ifru_netmask).map(Into::into)
@@ -345,8 +345,8 @@ impl D for Device {
             let mut req = self.request();
             req.ifr_ifru.ifru_netmask = SockAddr::from(value).into();
 
-            if siocsifnetmask(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifnetmask(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -357,8 +357,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifmtu(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifmtu(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(req.ifr_ifru.ifru_mtu)
@@ -370,8 +370,8 @@ impl D for Device {
             let mut req = self.request();
             req.ifr_ifru.ifru_mtu = value;
 
-            if siocsifmtu(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifmtu(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())

--- a/src/platform/linux/sys.rs
+++ b/src/platform/linux/sys.rs
@@ -14,24 +14,24 @@
 
 //! Bindings to internal Linux stuff.
 
-use ioctl::*;
 use libc::{c_int, ifreq};
+use nix::{ioctl_read_bad, ioctl_write_ptr, ioctl_write_ptr_bad};
 
-ioctl!(bad read siocgifflags with 0x8913; ifreq);
-ioctl!(bad write siocsifflags with 0x8914; ifreq);
-ioctl!(bad read siocgifaddr with 0x8915; ifreq);
-ioctl!(bad write siocsifaddr with 0x8916; ifreq);
-ioctl!(bad read siocgifdstaddr with 0x8917; ifreq);
-ioctl!(bad write siocsifdstaddr with 0x8918; ifreq);
-ioctl!(bad read siocgifbrdaddr with 0x8919; ifreq);
-ioctl!(bad write siocsifbrdaddr with 0x891a; ifreq);
-ioctl!(bad read siocgifnetmask with 0x891b; ifreq);
-ioctl!(bad write siocsifnetmask with 0x891c; ifreq);
-ioctl!(bad read siocgifmtu with 0x8921; ifreq);
-ioctl!(bad write siocsifmtu with 0x8922; ifreq);
-ioctl!(bad write siocsifname with 0x8923; ifreq);
+ioctl_read_bad!(siocgifflags, 0x8913, ifreq);
+ioctl_write_ptr_bad!(siocsifflags, 0x8914, ifreq);
+ioctl_read_bad!(siocgifaddr, 0x8915, ifreq);
+ioctl_write_ptr_bad!(siocsifaddr, 0x8916, ifreq);
+ioctl_read_bad!(siocgifdstaddr, 0x8917, ifreq);
+ioctl_write_ptr_bad!(siocsifdstaddr, 0x8918, ifreq);
+ioctl_read_bad!(siocgifbrdaddr, 0x8919, ifreq);
+ioctl_write_ptr_bad!(siocsifbrdaddr, 0x891a, ifreq);
+ioctl_read_bad!(siocgifnetmask, 0x891b, ifreq);
+ioctl_write_ptr_bad!(siocsifnetmask, 0x891c, ifreq);
+ioctl_read_bad!(siocgifmtu, 0x8921, ifreq);
+ioctl_write_ptr_bad!(siocsifmtu, 0x8922, ifreq);
+ioctl_write_ptr_bad!(siocsifname, 0x8923, ifreq);
 
-ioctl!(write tunsetiff with b'T', 202; c_int);
-ioctl!(write tunsetpersist with b'T', 203; c_int);
-ioctl!(write tunsetowner with b'T', 204; c_int);
-ioctl!(write tunsetgroup with b'T', 206; c_int);
+ioctl_write_ptr!(tunsetiff, b'T', 202, c_int);
+ioctl_write_ptr!(tunsetpersist, b'T', 203, c_int);
+ioctl_write_ptr!(tunsetowner, b'T', 204, c_int);
+ioctl_write_ptr!(tunsetgroup, b'T', 206, c_int);

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -83,8 +83,8 @@ impl Device {
                 },
             };
 
-            if ctliocginfo(tun.0, &mut info as *mut _ as *mut _) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = ctliocginfo(tun.0, &mut info as *mut _ as *mut _) {
+                return Err(io::Error::from(err).into());
             }
 
             let addr = sockaddr_ctl {
@@ -158,8 +158,8 @@ impl Device {
             req.broadaddr = SockAddr::from(broadaddr).into();
             req.mask = SockAddr::from(mask).into();
 
-            if siocaifaddr(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocaifaddr(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -223,8 +223,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifflags(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifflags(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             if value {
@@ -233,8 +233,8 @@ impl D for Device {
                 req.ifru.flags &= !(IFF_UP as c_short);
             }
 
-            if siocsifflags(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifflags(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -245,8 +245,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifaddr(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifaddr(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             SockAddr::new(&req.ifru.addr).map(Into::into)
@@ -258,8 +258,8 @@ impl D for Device {
             let mut req = self.request();
             req.ifru.addr = SockAddr::from(value).into();
 
-            if siocsifaddr(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifaddr(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -270,8 +270,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifdstaddr(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifdstaddr(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             SockAddr::new(&req.ifru.dstaddr).map(Into::into)
@@ -283,8 +283,8 @@ impl D for Device {
             let mut req = self.request();
             req.ifru.dstaddr = SockAddr::from(value).into();
 
-            if siocsifdstaddr(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifdstaddr(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -295,8 +295,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifbrdaddr(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifbrdaddr(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             SockAddr::new(&req.ifru.broadaddr).map(Into::into)
@@ -308,8 +308,8 @@ impl D for Device {
             let mut req = self.request();
             req.ifru.broadaddr = SockAddr::from(value).into();
 
-            if siocsifbrdaddr(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifbrdaddr(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -320,8 +320,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifnetmask(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifnetmask(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             SockAddr::unchecked(&req.ifru.addr).map(Into::into)
@@ -333,8 +333,8 @@ impl D for Device {
             let mut req = self.request();
             req.ifru.addr = SockAddr::from(value).into();
 
-            if siocsifnetmask(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifnetmask(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())
@@ -345,8 +345,8 @@ impl D for Device {
         unsafe {
             let mut req = self.request();
 
-            if siocgifmtu(self.ctl.as_raw_fd(), &mut req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocgifmtu(self.ctl.as_raw_fd(), &mut req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(req.ifru.mtu)
@@ -358,8 +358,8 @@ impl D for Device {
             let mut req = self.request();
             req.ifru.mtu = value;
 
-            if siocsifmtu(self.ctl.as_raw_fd(), &req) < 0 {
-                return Err(io::Error::last_os_error().into());
+            if let Err(err) = siocsifmtu(self.ctl.as_raw_fd(), &req) {
+                return Err(io::Error::from(err).into());
             }
 
             Ok(())

--- a/src/platform/macos/sys.rs
+++ b/src/platform/macos/sys.rs
@@ -14,8 +14,8 @@
 
 //! Bindings to internal macOS stuff.
 
-use ioctl::*;
 use libc::{c_char, c_int, c_short, c_uint, c_ushort, c_void, sockaddr, IFNAMSIZ};
+use nix::{ioctl_readwrite, ioctl_write_ptr};
 
 pub const UTUN_CONTROL_NAME: &str = "com.apple.net.utun_control";
 
@@ -109,25 +109,25 @@ pub struct ifaliasreq {
     pub mask: sockaddr,
 }
 
-ioctl!(readwrite ctliocginfo with 'N', 3; ctl_info);
+ioctl_readwrite!(ctliocginfo, b'N', 3, ctl_info);
 
-ioctl!(write siocsifflags with 'i', 16; ifreq);
-ioctl!(readwrite siocgifflags with 'i', 17; ifreq);
+ioctl_write_ptr!(siocsifflags, b'i', 16, ifreq);
+ioctl_readwrite!(siocgifflags, b'i', 17, ifreq);
 
-ioctl!(write siocsifaddr with 'i', 12; ifreq);
-ioctl!(readwrite siocgifaddr with 'i', 33; ifreq);
+ioctl_write_ptr!(siocsifaddr, b'i', 12, ifreq);
+ioctl_readwrite!(siocgifaddr, b'i', 33, ifreq);
 
-ioctl!(write siocsifdstaddr with 'i', 14; ifreq);
-ioctl!(readwrite siocgifdstaddr with 'i', 34; ifreq);
+ioctl_write_ptr!(siocsifdstaddr, b'i', 14, ifreq);
+ioctl_readwrite!(siocgifdstaddr, b'i', 34, ifreq);
 
-ioctl!(write siocsifbrdaddr with 'i', 19; ifreq);
-ioctl!(readwrite siocgifbrdaddr with 'i', 35; ifreq);
+ioctl_write_ptr!(siocsifbrdaddr, b'i', 19, ifreq);
+ioctl_readwrite!(siocgifbrdaddr, b'i', 35, ifreq);
 
-ioctl!(write siocsifnetmask with 'i', 22; ifreq);
-ioctl!(readwrite siocgifnetmask with 'i', 37; ifreq);
+ioctl_write_ptr!(siocsifnetmask, b'i', 22, ifreq);
+ioctl_readwrite!(siocgifnetmask, b'i', 37, ifreq);
 
-ioctl!(write siocsifmtu with 'i', 52; ifreq);
-ioctl!(readwrite siocgifmtu with 'i', 51; ifreq);
+ioctl_write_ptr!(siocsifmtu, b'i', 52, ifreq);
+ioctl_readwrite!(siocgifmtu, b'i', 51, ifreq);
 
-ioctl!(write siocaifaddr with 'i', 26; ifaliasreq);
-ioctl!(write siocdifaddr with 'i', 25; ifreq);
+ioctl_write_ptr!(siocaifaddr, b'i', 26, ifaliasreq);
+ioctl_write_ptr!(siocdifaddr, b'i', 25, ifreq);


### PR DESCRIPTION
This PR is going to replace the deprecated `ioctl` (or `ioctl-sys`) with a more actively maintained crate `nix`.

fixed #86 .