### PR TITLE
macos: add ipv6 addr

### DIFF
--- a/src/platform/macos/sys.rs
+++ b/src/platform/macos/sys.rs
@@ -15,7 +15,9 @@
 //! Bindings to internal macOS stuff.
 
 use ioctl::*;
-use libc::{c_char, c_int, c_short, c_uint, c_ushort, c_void, sockaddr, IFNAMSIZ};
+use libc::{
+    c_char, c_int, c_short, c_uint, c_ushort, c_void, sockaddr, sockaddr_in6, time_t, IFNAMSIZ,
+};
 
 pub const UTUN_CONTROL_NAME: &str = "com.apple.net.utun_control";
 
@@ -109,6 +111,28 @@ pub struct ifaliasreq {
     pub mask: sockaddr,
 }
 
+#[allow(non_camel_case_types)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct in6_aliasreq {
+    pub name: [c_char; IFNAMSIZ],
+    pub addr: sockaddr_in6,
+    pub dstaddr: sockaddr_in6,
+    pub prefixmask: sockaddr_in6,
+    pub flags: c_int,
+    pub lifetime: in6_addrlifetime,
+}
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct in6_addrlifetime {
+    pub ia6t_expire: time_t,
+    pub ia6t_preferred: time_t,
+    pub ia6t_vltime: u32,
+    pub ia6t_pltime: u32,
+}
+
 ioctl!(readwrite ctliocginfo with 'N', 3; ctl_info);
 
 ioctl!(write siocsifflags with 'i', 16; ifreq);
@@ -131,3 +155,5 @@ ioctl!(readwrite siocgifmtu with 'i', 51; ifreq);
 
 ioctl!(write siocaifaddr with 'i', 26; ifaliasreq);
 ioctl!(write siocdifaddr with 'i', 25; ifreq);
+
+ioctl!(write siocaifaddr_in6 with 'i', 26; in6_aliasreq);

--- a/src/platform/posix/mod.rs
+++ b/src/platform/posix/mod.rs
@@ -15,7 +15,7 @@
 //! POSIX compliant support.
 
 mod sockaddr;
-pub use self::sockaddr::SockAddr;
+pub use self::sockaddr::{SockAddr, SockAddrV6};
 
 mod fd;
 pub use self::fd::Fd;


### PR DESCRIPTION
This PR adds a method that provides a facility to set up IPv6 alias on tun device. Since it's possible to assign multiple IPv6 addresses on the same tun device, I figured that the method name should reflect that. This PR is very minimal and should be good enough for anyone looking to set up device with both IPv4 and IPv6

In this PR I introduce a `SockAddrV6` struct that compliments `SockAddr`. I think that both should be united under the `SockAddr` umbrella and `sockaddr` should be replaced with `sockaddr_stroage` which is large enough to hold both `sockaddr_in` and `sockaddr_in6` but I don't think that I am in capacity right now to test such change across multiple platforms.