### PR TITLE
fmt: fix clippy warnings

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -53,7 +53,7 @@ impl IntoAddress for str {
     }
 }
 
-impl<'a> IntoAddress for &'a str {
+impl IntoAddress for &str {
     fn into_address(&self) -> Result<Ipv4Addr> {
         (*self).into_address()
     }
@@ -65,7 +65,7 @@ impl IntoAddress for String {
     }
 }
 
-impl<'a> IntoAddress for &'a String {
+impl IntoAddress for &String {
     fn into_address(&self) -> Result<Ipv4Addr> {
         (**self).into_address()
     }
@@ -77,7 +77,7 @@ impl IntoAddress for Ipv4Addr {
     }
 }
 
-impl<'a> IntoAddress for &'a Ipv4Addr {
+impl IntoAddress for &Ipv4Addr {
     fn into_address(&self) -> Result<Ipv4Addr> {
         (**self).into_address()
     }
@@ -93,7 +93,7 @@ impl IntoAddress for IpAddr {
     }
 }
 
-impl<'a> IntoAddress for &'a IpAddr {
+impl IntoAddress for &IpAddr {
     fn into_address(&self) -> Result<Ipv4Addr> {
         (**self).into_address()
     }
@@ -105,7 +105,7 @@ impl IntoAddress for SocketAddrV4 {
     }
 }
 
-impl<'a> IntoAddress for &'a SocketAddrV4 {
+impl IntoAddress for &SocketAddrV4 {
     fn into_address(&self) -> Result<Ipv4Addr> {
         (**self).into_address()
     }
@@ -121,7 +121,7 @@ impl IntoAddress for SocketAddr {
     }
 }
 
-impl<'a> IntoAddress for &'a SocketAddr {
+impl IntoAddress for &SocketAddr {
     fn into_address(&self) -> Result<Ipv4Addr> {
         (**self).into_address()
     }

--- a/src/async/codec.rs
+++ b/src/async/codec.rs
@@ -20,6 +20,7 @@ use tokio_util::codec::{Decoder, Encoder};
 
 /// A packet protocol IP version
 #[derive(Debug, Clone, Copy, Default)]
+#[allow(dead_code)]
 enum PacketProtocol {
     #[default]
     IPv4,

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -87,7 +87,7 @@ impl Device {
                 | if queues_num > 1 { iff_multi_queue } else { 0 };
 
             for _ in 0..queues_num {
-                let tun = Fd::new(libc::open(b"/dev/net/tun\0".as_ptr() as *const _, O_RDWR))
+                let tun = Fd::new(libc::open(c"/dev/net/tun".as_ptr() as *const _, O_RDWR))
                     .map_err(|_| io::Error::last_os_error())?;
 
                 if tunsetiff(tun.0, &mut req as *mut _ as *mut _) < 0 {


### PR DESCRIPTION
## solution

fix clippy warnings, which can be checked by `cargo clippy --all-targets --all-features -- -D warnings`

