### PR TITLE
feat: add option to disable route setup on macOS

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -62,9 +62,6 @@ pub struct Configuration {
     pub(crate) metric: Option<u16>,
     #[cfg(unix)]
     pub(crate) close_fd_on_drop: Option<bool>,
-    /// Do not setup route for utun interface automatically
-    #[cfg(target_os = "macos")]
-    pub disable_routing: bool,
 }
 
 impl Configuration {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -62,6 +62,9 @@ pub struct Configuration {
     pub(crate) metric: Option<u16>,
     #[cfg(unix)]
     pub(crate) close_fd_on_drop: Option<bool>,
+    /// Do not setup route for utun interface automatically
+    #[cfg(target_os = "macos")]
+    pub disable_routing: bool,
 }
 
 impl Configuration {

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -172,7 +172,7 @@ impl Device {
             config
                 .netmask
                 .unwrap_or(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 0))),
-            config.disable_routing,
+            config.platform_config.disable_routing,
         )?;
 
         Ok(device)

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -172,6 +172,7 @@ impl Device {
             config
                 .netmask
                 .unwrap_or(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 0))),
+            config.disable_routing,
         )?;
 
         Ok(device)
@@ -192,7 +193,13 @@ impl Device {
     }
 
     /// Set the IPv4 alias of the device.
-    fn set_alias(&mut self, addr: IpAddr, broadaddr: IpAddr, mask: IpAddr) -> Result<()> {
+    fn set_alias(
+        &mut self,
+        addr: IpAddr,
+        broadaddr: IpAddr,
+        mask: IpAddr,
+        disable_routing: bool,
+    ) -> Result<()> {
         let IpAddr::V4(addr) = addr else {
             unimplemented!("do not support IPv6 yet")
         };
@@ -219,13 +226,15 @@ impl Device {
             if let Err(err) = siocaifaddr(ctl.as_raw_fd(), &req) {
                 return Err(std::io::Error::from(err).into());
             }
-            let route = Route {
-                addr,
-                netmask: mask,
-                dest: broadaddr,
-            };
-            if let Err(e) = self.set_route(route) {
-                log::warn!("{e:?}");
+            if !disable_routing {
+                let route = Route {
+                    addr,
+                    netmask: mask,
+                    dest: broadaddr,
+                };
+                if let Err(e) = self.set_route(route) {
+                    log::warn!("{e:?}");
+                }
             }
             Ok(())
         }

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -26,12 +26,14 @@ use crate::error::Result;
 #[derive(Copy, Clone, Debug)]
 pub struct PlatformConfig {
     pub(crate) packet_information: bool,
+    pub(crate) disable_routing: bool,
 }
 
 impl Default for PlatformConfig {
     fn default() -> Self {
         PlatformConfig {
             packet_information: true, // default is true in macOS
+            disable_routing: false,
         }
     }
 }
@@ -54,6 +56,12 @@ impl PlatformConfig {
     ///     and write packet via `[NEPacketTunnelProvider::packetFlow writePackets:withProtocols:]`, there is no PI.
     pub fn packet_information(&mut self, value: bool) -> &mut Self {
         self.packet_information = value;
+        self
+    }
+
+    /// Do not setup route for utun interface automatically
+    pub fn disable_routing(&mut self, value: bool) -> &mut Self {
+        self.disable_routing = value;
         self
     }
 }


### PR DESCRIPTION
We would like the option to disable the invocation of `route` on macOS, since we want to set up all routes ourselves. Improvement suggestions are welcome!