### PR TITLE
Add all android cpu architecture

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,10 @@ protocol = "sparse"
 [build]
 # target = ["x86_64-unknown-linux-musl"]
 # target = ["x86_64-unknown-linux-gnu"]
-# target = ["aarch64-linux-android"]
+# target = ["aarch64-linux-android"] # arm64-v8a 
+# target = ["armv7-linux-androideabi"] # armeabi-v7a 
+# target = ["i686-linux-android"] # x86
+# target = ["x86_64-linux-android"] # x86_64
 # target = ["aarch64-apple-ios"]
 # target = ["x86_64-pc-windows-msvc"]
 # target = ["x86_64-apple-darwin"]


### PR DESCRIPTION
Added all 4 android architectures as target.

| Android ABI      | Rust Target                  | Notes                  |
|------------------|------------------------------|------------------------|
| `arm64-v8a`      | `aarch64-linux-android`      | 64-bit ARM (modern)    |
| `armeabi-v7a`    | `armv7-linux-androideabi`    | 32-bit ARM (legacy)    |
| `x86`            | `i686-linux-android`         | 32-bit Intel (rare)    |
| `x86_64`         | `x86_64-linux-android`       | 64-bit Intel (emulator)|
