### PR TITLE
fixed ioctl types for linux

### DIFF
--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -16,6 +16,7 @@ use libc::{
     self, AF_INET, IFF_MULTI_QUEUE, IFF_NAPI, IFF_NO_PI, IFF_RUNNING, IFF_TAP, IFF_TUN, IFF_UP,
     IFF_VNET_HDR, IFNAMSIZ, O_RDWR, SOCK_DGRAM, c_char, c_short, ifreq,
 };
+use nix::sys::ioctl::ioctl_param_type;
 use std::{
     ffi::{CStr, CString},
     io::{Read, Write},
@@ -165,7 +166,7 @@ impl Device {
     /// Make the device persistent.
     pub fn persist(&mut self) -> Result<()> {
         unsafe {
-            if let Err(err) = tunsetpersist(self.as_raw_fd(), &1) {
+            if let Err(err) = tunsetpersist(self.as_raw_fd(), 1) {
                 Err(std::io::Error::from(err).into())
             } else {
                 Ok(())
@@ -176,7 +177,7 @@ impl Device {
     /// Set the owner of the device.
     pub fn user(&mut self, value: i32) -> Result<()> {
         unsafe {
-            if let Err(err) = tunsetowner(self.as_raw_fd(), &value) {
+            if let Err(err) = tunsetowner(self.as_raw_fd(), value as ioctl_param_type) {
                 Err(std::io::Error::from(err).into())
             } else {
                 Ok(())
@@ -187,7 +188,7 @@ impl Device {
     /// Set the group of the device.
     pub fn group(&mut self, value: i32) -> Result<()> {
         unsafe {
-            if let Err(err) = tunsetgroup(self.as_raw_fd(), &value) {
+            if let Err(err) = tunsetgroup(self.as_raw_fd(), value as ioctl_param_type) {
                 Err(std::io::Error::from(err).into())
             } else {
                 Ok(())

--- a/src/platform/linux/sys.rs
+++ b/src/platform/linux/sys.rs
@@ -15,7 +15,7 @@
 //! Bindings to internal Linux stuff.
 
 use libc::{c_int, ifreq};
-use nix::{ioctl_read_bad, ioctl_write_ptr, ioctl_write_ptr_bad};
+use nix::{ioctl_read_bad, ioctl_write_int, ioctl_write_ptr, ioctl_write_ptr_bad};
 
 ioctl_read_bad!(siocgifflags, 0x8913, ifreq);
 ioctl_write_ptr_bad!(siocsifflags, 0x8914, ifreq);
@@ -32,6 +32,6 @@ ioctl_write_ptr_bad!(siocsifmtu, 0x8922, ifreq);
 ioctl_write_ptr_bad!(siocsifname, 0x8923, ifreq);
 
 ioctl_write_ptr!(tunsetiff, b'T', 202, c_int);
-ioctl_write_ptr!(tunsetpersist, b'T', 203, c_int);
-ioctl_write_ptr!(tunsetowner, b'T', 204, c_int);
-ioctl_write_ptr!(tunsetgroup, b'T', 206, c_int);
+ioctl_write_int!(tunsetpersist, b'T', 203);
+ioctl_write_int!(tunsetowner, b'T', 204);
+ioctl_write_int!(tunsetgroup, b'T', 206);


### PR DESCRIPTION
The `TUNSETPERSIST`, `TUNSETOWNER`, and `TUNSETGROUP` ioctls on linux take the argument as value instead of as pointer. This broke `Device::user` but `Device::persist` still worked because the kernel checks the value as non-zero which any valid pointer always is.

This can be checked with.
```
sudo strace ip tuntap add dev test mode tun user 1000 group 1000
```
which does
```
openat(AT_FDCWD, "/dev/net/tun", O_RDWR) = 4
ioctl(4, TUNSETIFF, 0x7ffd315477a0)     = 0
ioctl(4, TUNSETOWNER, 0x3e8)            = 0
ioctl(4, TUNSETGROUP, 0x3e8)            = 0
ioctl(4, TUNSETPERSIST, 0x1)            = 0
close(4)                                = 0
```