### PR TITLE
Replace netsh for setting interface metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ ipnet = "2"
 futures = { version = "0.3", optional = true }
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
+    "Win32_Networking_WinSock",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_NetworkManagement_IpHelper",
     "Win32_Security",
     "Win32_Security_WinTrust",
     "Win32_Security_Cryptography",

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -46,12 +46,6 @@ impl Device {
                     Adapter::create(&wintun, tun_name, tun_name, guid)?
                 }
             };
-            if let Some(metric) = config.metric {
-                // SAFETY: LUID is always a u64
-                let luid = unsafe { adapter.get_luid().Value };
-                set_interface_metric(luid, metric.into(), false)?;
-                set_interface_metric(luid, metric.into(), true)?;
-            }
             let address = config
                 .address
                 .unwrap_or(IpAddr::V4(Ipv4Addr::new(10, 1, 0, 2)));
@@ -60,6 +54,12 @@ impl Device {
                 .unwrap_or(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 0)));
             let gateway = config.destination;
             adapter.set_network_addresses_tuple(address, mask, gateway)?;
+            if let Some(metric) = config.metric {
+                // SAFETY: LUID is always a u64
+                let luid = unsafe { adapter.get_luid().Value };
+                set_interface_metric(luid, metric.into(), false)?;
+                set_interface_metric(luid, metric.into(), true)?;
+            }
             if let Some(dns_servers) = &config.platform_config.dns_servers {
                 adapter.set_dns_servers(dns_servers)?;
             }


### PR DESCRIPTION
This should be a bit nicer and faster than relying on netsh.