### PR TITLE
Make it possible to disable wintun.dll verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 crate-type = ["staticlib", "lib"]
 
 [features]
-# default = ["async"]
+# default = ["async", "verify_binary_signature"]
 async = [
     "tokio",
     "futures-core",
@@ -24,6 +24,7 @@ async = [
     "tokio-util",
     "wintun-bindings/async",
 ]
+verify_binary_signature = ["wintun-bindings/verify_binary_signature"]
 
 [dependencies]
 bytes = { version = "1" }
@@ -55,7 +56,6 @@ windows-sys = { version = "0.61", features = [
 ] }
 wintun-bindings = { version = "^0.7.7", features = [
     "panic_on_unsent_packets",
-    "verify_binary_signature",
     "async",
     "enable_inner_logging",
     "winreg",


### PR DESCRIPTION
We're having some issues with the verification being very slow, possibly because our app blocks internet traffic. (This is only a guess.)

In our case, we do not want/need the check, as we can already trust the that the correct DLL is being loaded, and we point to it using its absolute path. So we would like to to disable it.

I'm not sure if this solution is ideal, since it's still pretty easy to accidentally enable the feature with `tun` as a transitive dependency. Would you be open to this being a configurable option instead?