### PR TITLE
Expose interface LUID on Windows

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -53,7 +53,7 @@ pub use self::ohos::{Device, PlatformConfig, create};
 #[cfg(target_os = "windows")]
 pub(crate) mod windows;
 #[cfg(target_os = "windows")]
-pub use self::windows::{Device, PlatformConfig, Reader, Tun, Writer, create};
+pub use self::windows::{AbstractDeviceExt, Device, PlatformConfig, Reader, Tun, Writer, create};
 
 #[cfg(test)]
 mod test {

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -21,6 +21,7 @@ use crate::configuration::Configuration;
 use crate::device::AbstractDevice;
 use crate::error::{Error, Result};
 use crate::run_command::run_command;
+use crate::windows::AbstractDeviceExt;
 use wintun_bindings::{Adapter, MAX_RING_CAPACITY, Session, load_from_path};
 
 /// A TUN device using the wintun driver.
@@ -212,6 +213,13 @@ impl AbstractDevice for Device {
     fn packet_information(&self) -> bool {
         // Note: wintun does not support packet information
         false
+    }
+}
+
+impl AbstractDeviceExt for Device {
+    fn tun_luid(&self) -> u64 {
+        // SAFETY: LUID is always a u64
+        unsafe { self.tun.session.get_adapter().get_luid().Value }
     }
 }
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -16,10 +16,15 @@
 
 mod device;
 
-use crate::configuration::Configuration;
 use crate::error::Result;
+use crate::{AbstractDevice, configuration::Configuration};
 pub use device::{Device, Reader, Tun, Writer};
 use std::ffi::OsString;
+
+/// Platform-specific extensions for the abstract device.
+pub trait AbstractDeviceExt: AbstractDevice {
+    fn tun_luid(&self) -> u64;
+}
 
 /// Windows-only interface configuration.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
I've found myself wanting to use the interface LUID of the tunnel interface. This can already be retrieved from the alias or index, but since we it is already known, we could skip that extra step. Hence this PR.