### PR TITLE
Add Clone functionality to DeviceWriter

### DIFF
--- a/src/async/unix_device.rs
+++ b/src/async/unix_device.rs
@@ -179,6 +179,7 @@ impl AsyncRead for DeviceReader {
     }
 }
 
+#[derive(Clone)]
 pub struct DeviceWriter {
     inner: std::sync::Arc<AsyncFd<Device>>,
 }

--- a/src/async/win_device.rs
+++ b/src/async/win_device.rs
@@ -135,6 +135,7 @@ impl AsyncRead for DeviceReader {
     }
 }
 
+#[derive(Clone)]
 pub struct DeviceWriter {
     session: AsyncSession,
 }


### PR DESCRIPTION
Simple derive Clone for async DeviceWriter.

When using the async split API, it is sometimes useful to share the write half across multiple tasks. 
With this change, DeviceWriter can be cloned directly, making it easier to send packets from multiple async tasks using the same device writer.

### Benefits
- simplifies concurrent write usage
- reduces the need for extra synchronization in user code
- preserves existing behavior and only extends the API surface