### PR TITLE
Add recv_timeout to the sync Device and Reader, make set_nonblock public again

### DIFF
--- a/examples/recv-timeout.rs
+++ b/examples/recv-timeout.rs
@@ -1,0 +1,68 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+//! Reads from the device on a dedicated thread and shuts that thread down
+//! cleanly, without routing a wake-up packet into the interface and without
+//! leaking the device. `recv_timeout` bounds every read, so the thread
+//! notices the stop flag within one timeout interval.
+
+#[cfg(unix)]
+fn main() -> Result<(), tun::BoxError> {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
+
+    let mut config = tun::Configuration::default();
+
+    config
+        .address((10, 0, 0, 9))
+        .netmask((255, 255, 255, 0))
+        .destination((10, 0, 0, 1))
+        .up();
+
+    #[cfg(target_os = "linux")]
+    config.platform_config(|config| {
+        config.ensure_root_privileges(true);
+    });
+
+    let dev = tun::create(&config)?;
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let reader_stop = stop.clone();
+    let reader = std::thread::spawn(move || -> std::io::Result<()> {
+        let mut buf = [0; 4096];
+        while !reader_stop.load(Ordering::Relaxed) {
+            match dev.recv_timeout(&mut buf, Duration::from_millis(500)) {
+                Ok(amount) => println!("{:?}", &buf[0..amount]),
+                Err(err) if err.kind() == std::io::ErrorKind::TimedOut => continue,
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(())
+    });
+
+    println!("reading for 5 seconds, then asking the reader to stop");
+    std::thread::sleep(Duration::from_secs(5));
+    stop.store(true, Ordering::Relaxed);
+    reader.join().unwrap()?;
+    println!("reader thread stopped cleanly");
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn main() {
+    println!("recv_timeout is not available on this platform");
+}

--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -77,6 +77,23 @@ impl Device {
         self.tun.recv(buf)
     }
 
+    /// Recv a packet from tun device, waiting at most `timeout`.
+    ///
+    /// A TUN device is a character device, so `SO_RCVTIMEO`-style read
+    /// timeouts do not apply; this is implemented as poll(2) followed by a
+    /// read on every call. If no packet arrives within `timeout`, an error
+    /// of kind `std::io::ErrorKind::TimedOut` is returned. A zero `timeout`
+    /// checks for a packet without blocking. If several threads receive from
+    /// the same device concurrently, another thread may consume the packet
+    /// first and the read may still block.
+    pub fn recv_timeout(
+        &self,
+        buf: &mut [u8],
+        timeout: std::time::Duration,
+    ) -> std::io::Result<usize> {
+        self.tun.recv_timeout(buf, timeout)
+    }
+
     /// Send a packet to tun device
     pub fn send(&self, buf: &[u8]) -> std::io::Result<usize> {
         self.tun.send(buf)

--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -68,8 +68,7 @@ impl Device {
     }
 
     /// Set non-blocking mode
-    #[allow(dead_code)]
-    pub(crate) fn set_nonblock(&self) -> std::io::Result<()> {
+    pub fn set_nonblock(&self) -> std::io::Result<()> {
         self.tun.set_nonblock()
     }
 

--- a/src/platform/freebsd/device.rs
+++ b/src/platform/freebsd/device.rs
@@ -195,8 +195,7 @@ impl Device {
     }
 
     /// Set non-blocking mode
-    #[allow(dead_code)]
-    pub(crate) fn set_nonblock(&self) -> std::io::Result<()> {
+    pub fn set_nonblock(&self) -> std::io::Result<()> {
         self.tun.set_nonblock()
     }
 

--- a/src/platform/freebsd/device.rs
+++ b/src/platform/freebsd/device.rs
@@ -240,6 +240,23 @@ impl Device {
         self.tun.recv(buf)
     }
 
+    /// Recv a packet from tun device, waiting at most `timeout`.
+    ///
+    /// A TUN device is a character device, so `SO_RCVTIMEO`-style read
+    /// timeouts do not apply; this is implemented as poll(2) followed by a
+    /// read on every call. If no packet arrives within `timeout`, an error
+    /// of kind `std::io::ErrorKind::TimedOut` is returned. A zero `timeout`
+    /// checks for a packet without blocking. If several threads receive from
+    /// the same device concurrently, another thread may consume the packet
+    /// first and the read may still block.
+    pub fn recv_timeout(
+        &self,
+        buf: &mut [u8],
+        timeout: std::time::Duration,
+    ) -> std::io::Result<usize> {
+        self.tun.recv_timeout(buf, timeout)
+    }
+
     /// Send a packet to tun device
     pub fn send(&self, buf: &[u8]) -> std::io::Result<usize> {
         self.tun.send(buf)

--- a/src/platform/ios/device.rs
+++ b/src/platform/ios/device.rs
@@ -73,8 +73,7 @@ impl Device {
     }
 
     /// Set non-blocking mode
-    #[allow(dead_code)]
-    pub(crate) fn set_nonblock(&self) -> std::io::Result<()> {
+    pub fn set_nonblock(&self) -> std::io::Result<()> {
         self.tun.set_nonblock()
     }
 

--- a/src/platform/ios/device.rs
+++ b/src/platform/ios/device.rs
@@ -82,6 +82,23 @@ impl Device {
         self.tun.recv(buf)
     }
 
+    /// Recv a packet from tun device, waiting at most `timeout`.
+    ///
+    /// A TUN device is a character device, so `SO_RCVTIMEO`-style read
+    /// timeouts do not apply; this is implemented as poll(2) followed by a
+    /// read on every call. If no packet arrives within `timeout`, an error
+    /// of kind `std::io::ErrorKind::TimedOut` is returned. A zero `timeout`
+    /// checks for a packet without blocking. If several threads receive from
+    /// the same device concurrently, another thread may consume the packet
+    /// first and the read may still block.
+    pub fn recv_timeout(
+        &self,
+        buf: &mut [u8],
+        timeout: std::time::Duration,
+    ) -> std::io::Result<usize> {
+        self.tun.recv_timeout(buf, timeout)
+    }
+
     /// Send a packet to tun device
     pub fn send(&self, buf: &[u8]) -> std::io::Result<usize> {
         self.tun.send(buf)

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -202,8 +202,7 @@ impl Device {
     }
 
     /// Set non-blocking mode
-    #[allow(dead_code)]
-    pub(crate) fn set_nonblock(&self) -> std::io::Result<()> {
+    pub fn set_nonblock(&self) -> std::io::Result<()> {
         self.tun.set_nonblock()
     }
 

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -211,6 +211,23 @@ impl Device {
         self.tun.recv(buf)
     }
 
+    /// Recv a packet from tun device, waiting at most `timeout`.
+    ///
+    /// A TUN device is a character device, so `SO_RCVTIMEO`-style read
+    /// timeouts do not apply; this is implemented as poll(2) followed by a
+    /// read on every call. If no packet arrives within `timeout`, an error
+    /// of kind `std::io::ErrorKind::TimedOut` is returned. A zero `timeout`
+    /// checks for a packet without blocking. If several threads receive from
+    /// the same device concurrently, another thread may consume the packet
+    /// first and the read may still block.
+    pub fn recv_timeout(
+        &self,
+        buf: &mut [u8],
+        timeout: std::time::Duration,
+    ) -> std::io::Result<usize> {
+        self.tun.recv_timeout(buf, timeout)
+    }
+
     /// Send a packet to tun device
     pub fn send(&self, buf: &[u8]) -> std::io::Result<usize> {
         self.tun.send(buf)

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -279,6 +279,23 @@ impl Device {
         self.tun.recv(buf)
     }
 
+    /// Recv a packet from tun device, waiting at most `timeout`.
+    ///
+    /// A TUN device is a character device, so `SO_RCVTIMEO`-style read
+    /// timeouts do not apply; this is implemented as poll(2) followed by a
+    /// read on every call. If no packet arrives within `timeout`, an error
+    /// of kind `std::io::ErrorKind::TimedOut` is returned. A zero `timeout`
+    /// checks for a packet without blocking. If several threads receive from
+    /// the same device concurrently, another thread may consume the packet
+    /// first and the read may still block.
+    pub fn recv_timeout(
+        &self,
+        buf: &mut [u8],
+        timeout: std::time::Duration,
+    ) -> std::io::Result<usize> {
+        self.tun.recv_timeout(buf, timeout)
+    }
+
     /// Send a packet to tun device
     pub fn send(&self, buf: &[u8]) -> std::io::Result<usize> {
         self.tun.send(buf)

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -235,8 +235,7 @@ impl Device {
     }
 
     /// Set non-blocking mode
-    #[allow(dead_code)]
-    pub(crate) fn set_nonblock(&self) -> std::io::Result<()> {
+    pub fn set_nonblock(&self) -> std::io::Result<()> {
         self.tun.set_nonblock()
     }
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -85,4 +85,45 @@ mod test {
 
         assert_eq!(crate::DEFAULT_MTU, dev.mtu().unwrap());
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn recv_timeout_times_out_on_a_silent_device() {
+        use std::time::{Duration, Instant};
+
+        // The device is never brought up, so no traffic can reach it.
+        let config = Configuration::default();
+        let dev = super::create(&config).unwrap();
+        let mut buf = [0u8; crate::DEFAULT_MTU as usize];
+        let timeout = Duration::from_millis(100);
+        let start = Instant::now();
+        let err = dev.recv_timeout(&mut buf, timeout).unwrap_err();
+        let elapsed = start.elapsed();
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        assert!(elapsed >= timeout, "returned after {elapsed:?}");
+        assert!(elapsed < Duration::from_secs(10), "took {elapsed:?}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn recv_timeout_returns_a_packet_arriving_before_expiry() {
+        use std::time::Duration;
+
+        let dev = super::create(
+            Configuration::default()
+                .address("192.168.51.1")
+                .netmask("255.255.255.0")
+                .up(),
+        )
+        .unwrap();
+
+        // Route a packet into the device from the kernel side; it stays
+        // queued on the interface until the read below picks it up.
+        let socket = std::net::UdpSocket::bind("192.168.51.1:0").unwrap();
+        socket.send_to(b"ping", "192.168.51.2:9").unwrap();
+
+        let mut buf = [0u8; crate::DEFAULT_MTU as usize];
+        let amount = dev.recv_timeout(&mut buf, Duration::from_secs(5)).unwrap();
+        assert!(amount > 0);
+    }
 }

--- a/src/platform/ohos/device.rs
+++ b/src/platform/ohos/device.rs
@@ -65,8 +65,7 @@ impl Device {
     }
 
     /// Set non-blocking mode
-    #[allow(dead_code)]
-    pub(crate) fn set_nonblock(&self) -> std::io::Result<()> {
+    pub fn set_nonblock(&self) -> std::io::Result<()> {
         self.tun.set_nonblock()
     }
 

--- a/src/platform/ohos/device.rs
+++ b/src/platform/ohos/device.rs
@@ -74,6 +74,23 @@ impl Device {
         self.tun.recv(buf)
     }
 
+    /// Recv a packet from tun device, waiting at most `timeout`.
+    ///
+    /// A TUN device is a character device, so `SO_RCVTIMEO`-style read
+    /// timeouts do not apply; this is implemented as poll(2) followed by a
+    /// read on every call. If no packet arrives within `timeout`, an error
+    /// of kind `std::io::ErrorKind::TimedOut` is returned. A zero `timeout`
+    /// checks for a packet without blocking. If several threads receive from
+    /// the same device concurrently, another thread may consume the packet
+    /// first and the read may still block.
+    pub fn recv_timeout(
+        &self,
+        buf: &mut [u8],
+        timeout: std::time::Duration,
+    ) -> std::io::Result<usize> {
+        self.tun.recv_timeout(buf, timeout)
+    }
+
     /// Send a packet to tun device
     pub fn send(&self, buf: &[u8]) -> std::io::Result<usize> {
         self.tun.send(buf)

--- a/src/platform/posix/fd.rs
+++ b/src/platform/posix/fd.rs
@@ -41,6 +41,53 @@ impl Fd {
         }
     }
 
+    /// Wait until the file descriptor becomes readable or `timeout` expires.
+    ///
+    /// Returns an error of kind `std::io::ErrorKind::TimedOut` if the
+    /// descriptor does not become readable within `timeout`. A zero
+    /// `timeout` checks readability without blocking. If poll(2) reports an
+    /// error or hangup condition instead of readability, this returns
+    /// `Ok(())` and lets the following read report the actual condition.
+    pub(crate) fn wait_readable(&self, timeout: std::time::Duration) -> std::io::Result<()> {
+        let deadline = std::time::Instant::now().checked_add(timeout);
+        loop {
+            // Round the remaining time up to whole milliseconds so a
+            // fractional remainder does not turn into a zero-timeout poll
+            // before the deadline is actually reached.
+            let millis = match deadline {
+                Some(deadline) => {
+                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                    libc::c_int::try_from(remaining.as_nanos().div_ceil(1_000_000))
+                        .unwrap_or(libc::c_int::MAX)
+                }
+                // `timeout` overflows `Instant`; wait as long as poll(2)
+                // allows per call and keep re-arming.
+                None => libc::c_int::MAX,
+            };
+            let mut pollfd = libc::pollfd {
+                fd: self.inner,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            match unsafe { libc::poll(&mut pollfd, 1, millis) } {
+                -1 => {
+                    let err = std::io::Error::last_os_error();
+                    if err.kind() != std::io::ErrorKind::Interrupted {
+                        return Err(err);
+                    }
+                    // Interrupted by a signal; re-arm with the remaining time.
+                }
+                0 => {
+                    if deadline.is_some_and(|deadline| std::time::Instant::now() >= deadline) {
+                        return Err(std::io::ErrorKind::TimedOut.into());
+                    }
+                    // The wait was clamped below the remaining time; re-arm.
+                }
+                _ => return Ok(()),
+            }
+        }
+    }
+
     #[inline]
     pub fn read(&self, buf: &mut [u8]) -> std::io::Result<usize> {
         let fd = self.as_raw_fd();
@@ -141,4 +188,64 @@ pub(crate) const fn max_iov() -> usize {
 ))]
 pub(crate) const fn max_iov() -> usize {
     libc::UIO_MAXIOV as usize
+}
+
+#[cfg(test)]
+mod test {
+    use super::Fd;
+    use std::time::{Duration, Instant};
+
+    fn pipe() -> (Fd, Fd) {
+        let mut fds = [0; 2];
+        let res = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(
+            res,
+            0,
+            "pipe(2) failed: {}",
+            std::io::Error::last_os_error()
+        );
+        (
+            Fd::new(fds[0], true).unwrap(),
+            Fd::new(fds[1], true).unwrap(),
+        )
+    }
+
+    #[test]
+    fn wait_readable_times_out_on_a_silent_fd() {
+        let (rx, _tx) = pipe();
+        let timeout = Duration::from_millis(100);
+        let start = Instant::now();
+        let err = rx.wait_readable(timeout).unwrap_err();
+        let elapsed = start.elapsed();
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        assert!(elapsed >= timeout, "returned after {elapsed:?}");
+        assert!(elapsed < Duration::from_secs(10), "took {elapsed:?}");
+    }
+
+    #[test]
+    fn wait_readable_sees_data_already_present() {
+        let (rx, tx) = pipe();
+        tx.write(b"x").unwrap();
+        rx.wait_readable(Duration::from_secs(5)).unwrap();
+    }
+
+    #[test]
+    fn wait_readable_wakes_when_data_arrives_before_expiry() {
+        let (rx, tx) = pipe();
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            tx.write(b"x").unwrap();
+        });
+        let start = Instant::now();
+        rx.wait_readable(Duration::from_secs(10)).unwrap();
+        assert!(start.elapsed() < Duration::from_secs(10));
+        writer.join().unwrap();
+    }
+
+    #[test]
+    fn wait_readable_zero_timeout_does_not_block() {
+        let (rx, _tx) = pipe();
+        let err = rx.wait_readable(Duration::ZERO).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+    }
 }

--- a/src/platform/posix/split.rs
+++ b/src/platform/posix/split.rs
@@ -259,8 +259,7 @@ impl Tun {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn set_nonblock(&self) -> std::io::Result<()> {
+    pub fn set_nonblock(&self) -> std::io::Result<()> {
         self.reader.fd.set_nonblock()
     }
 

--- a/src/platform/posix/split.rs
+++ b/src/platform/posix/split.rs
@@ -110,6 +110,24 @@ impl Reader {
         }
         Ok(amount - self.offset)
     }
+
+    /// Recv a packet from tun device, waiting at most `timeout`.
+    ///
+    /// A TUN device is a character device, so `SO_RCVTIMEO`-style read
+    /// timeouts do not apply; this is implemented as poll(2) followed by a
+    /// read on every call. If no packet arrives within `timeout`, an error
+    /// of kind `std::io::ErrorKind::TimedOut` is returned. A zero `timeout`
+    /// checks for a packet without blocking. If several threads receive from
+    /// the same device concurrently, another thread may consume the packet
+    /// first and the read may still block.
+    pub fn recv_timeout(
+        &self,
+        buf: &mut [u8],
+        timeout: std::time::Duration,
+    ) -> std::io::Result<usize> {
+        self.fd.wait_readable(timeout)?;
+        self.recv(buf)
+    }
 }
 
 impl Read for Reader {
@@ -282,6 +300,14 @@ impl Tun {
         self.reader.recv(buf)
     }
 
+    pub fn recv_timeout(
+        &self,
+        buf: &mut [u8],
+        timeout: std::time::Duration,
+    ) -> std::io::Result<usize> {
+        self.reader.recv_timeout(buf, timeout)
+    }
+
     pub fn send(&self, buf: &[u8]) -> std::io::Result<usize> {
         self.writer.send(buf)
     }
@@ -315,5 +341,53 @@ impl IntoRawFd for Tun {
         // guarantee fd is the unique owner such that Arc::into_inner can return some
         let fd = Arc::into_inner(self.reader.fd).unwrap(); // panic if accident
         fd.into_raw_fd()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Tun;
+    use crate::platform::posix::Fd;
+    use std::time::{Duration, Instant};
+
+    fn pipe() -> (Fd, Fd) {
+        let mut fds = [0; 2];
+        let res = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(
+            res,
+            0,
+            "pipe(2) failed: {}",
+            std::io::Error::last_os_error()
+        );
+        (
+            Fd::new(fds[0], true).unwrap(),
+            Fd::new(fds[1], true).unwrap(),
+        )
+    }
+
+    #[test]
+    fn recv_timeout_times_out_on_a_silent_fd() {
+        let (rx, _tx) = pipe();
+        let tun = Tun::new(rx, 1500, false);
+        let mut buf = [0u8; 1500];
+        let timeout = Duration::from_millis(100);
+        let start = Instant::now();
+        let err = tun.recv_timeout(&mut buf, timeout).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        assert!(start.elapsed() >= timeout);
+    }
+
+    #[test]
+    fn recv_timeout_returns_data_arriving_before_expiry() {
+        let (rx, tx) = pipe();
+        let tun = Tun::new(rx, 1500, false);
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            tx.write(b"hello").unwrap();
+        });
+        let mut buf = [0u8; 1500];
+        let amount = tun.recv_timeout(&mut buf, Duration::from_secs(10)).unwrap();
+        assert_eq!(&buf[..amount], b"hello");
+        writer.join().unwrap();
     }
 }


### PR DESCRIPTION
Opening this per your note on #165.

Closes #165.

`set_nonblock` becomes public again on the sync unix `Device` (hidden in #122; #165 has the background on why the sync path still needs it), and the sync path gets a bounded read:

```rust
pub fn recv_timeout(&self, buf: &mut [u8], timeout: Duration) -> std::io::Result<usize>
```

on the platform devices (linux, macos, freebsd, android, ios, ohos), on the split `Reader`, and on the internal `Tun`.

Implementation notes:

* A TUN fd is a character device, so `SO_RCVTIMEO` is not an option. `recv_timeout` runs poll(2) and then the usual read on every call, and the doc comments say so. On expiry it returns `ErrorKind::TimedOut`.
* The poll loop in `Fd::wait_readable` re-arms on `EINTR` against a monotonic deadline, rounds the remaining time up to whole milliseconds so there is no zero-timeout spin near the deadline, and clamps oversized durations to repeated `c_int::MAX` waits. A zero `timeout` is a non-blocking readability check.
* If poll reports an error or hangup instead of readability, the wait returns and the following read reports the actual condition.
* No existing path changes behavior. The `set_nonblock` commit is a visibility change only, and `recv_timeout` is purely additive, so this is minor-version material. The two commits are independent; if you'd rather not revisit #122, the `set_nonblock` one can be dropped and `recv_timeout` still stands on its own.
* Windows is left out on purpose. The method does not exist on the Windows `Device`, the same way `persist`, `user` and `group` only exist on Linux. The platform question is open in #165.

Tests: `posix::fd` and `posix::split` get unit tests that drive `wait_readable` and `recv_timeout` against a pipe. A silent fd times out with `TimedOut` no earlier than the requested timeout, and data arriving before expiry comes back intact. These run with plain `cargo test` and need no device or privileges. Two device-level tests sit next to the existing `platform::test::create` test and follow its convention, so like it they need a TUN-capable host and privileges: one checks `TimedOut` on a device that is never brought up, the other routes a UDP packet into the device through the kernel and reads it back with `recv_timeout`. There is also an `examples/recv-timeout.rs` showing the reader-thread shutdown pattern end to end.

Verified locally on Linux as root: `cargo fmt --all -- --check`, `cargo check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build --examples --tests --all-features --features="async tokio/rt-multi-thread"`, `cargo build --examples --tests --no-default-features`, and `cargo test` under default features, `--no-default-features`, and `--all-features` (10 of 10 passing, including the two real-device tests). I also ran the example against a real device with UDP traffic routed in mid-wait; the packets came through and the reader shut down cleanly.

The three commits are independent. `recv_timeout` (the middle one) is the actual goal and stands entirely on its own. The other two are optional: `set_nonblock` (first) restores something #122 removed and isn't needed by `recv_timeout`, and the example (last) just demonstrates the shutdown pattern. Both can be dropped without touching the feature. Happy to split into separate PRs, trim the doc comments, or cut the example if you'd prefer a smaller diff.